### PR TITLE
fix: Remove non-existent config directory from release script

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -85,12 +85,6 @@ const main = async () => {
     path.join(archiveDir, 'WORKSPACE-Context.md')
   );
 
-  // Copy the config directory
-  fs.cpSync(
-    path.join(workspaceMcpServerDir, 'config'),
-    path.join(archiveDir, 'config'),
-    { recursive: true }
-  );
 
   // Create the archive
   const output = fs.createWriteStream(path.join(releaseDir, archiveName));


### PR DESCRIPTION
The `config` directory was removed in a previous change, causing the release script to fail. This PR removes the attempt to copy it.