### PR TITLE
fix: restore auth on startup

### DIFF
--- a/workspace-mcp-server/src/index.ts
+++ b/workspace-mcp-server/src/index.ts
@@ -55,6 +55,9 @@ async function main() {
     }
 
     const authManager = new AuthManager(SCOPES);
+    // Trigger auth flow immediately on startup
+    await authManager.getAuthenticatedClient();
+
     const driveService = new DriveService(authManager);
     const docsService = new DocsService(authManager, driveService);
     const peopleService = new PeopleService(authManager);


### PR DESCRIPTION
Restores the behavior where the authentication flow is triggered immediately upon server startup. This ensures that users are prompted to authenticate (if needed) as soon as the plugin is launched, rather than waiting for the first tool usage.