### PR TITLE
fix: remove invalid assignees from dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,8 +5,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    assignees:
-      - "google-gemini"
     labels:
       - "dependencies"
       - "npm"
@@ -19,8 +17,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    assignees:
-      - "google-gemini"
     labels:
       - "dependencies"
       - "npm"
@@ -33,8 +29,6 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5
-    assignees:
-      - "google-gemini"
     labels:
       - "dependencies"
       - "github-actions"


### PR DESCRIPTION
The user 'google-gemini' is not a valid assignee for this repository, causing dependabot errors.
This PR removes the 'assignees' field from the dependabot configuration.