### PR TITLE
fix: strip leading 'v' from version in release script

### DIFF
--- a/scripts/release.js
+++ b/scripts/release.js
@@ -83,10 +83,7 @@ const main = async () => {
   });
 
   const packageJson = require('../package.json');
-  let version = process.env.GITHUB_REF_NAME || packageJson.version;
-  if (version.startsWith('v')) {
-    version = version.slice(1);
-  }
+  const version = (process.env.GITHUB_REF_NAME || packageJson.version).replace(/^v/, '');
 
   // Generate the gemini-extension.json file
   const geminiExtensionJson = {


### PR DESCRIPTION
This fixes an issue where the version string in gemini-extension.json would contain a leading 'v' (e.g. v0.0.2) when built from a git tag, resulting in a double 'v' display (vv0.0.2) in the CLI.

Fixes #64