### PR TITLE
fix(chat): document Google Chat Markdown formatting in tool descriptions

### DIFF
--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -456,10 +456,10 @@ async function main() {
     server.registerTool(
         "chat.sendMessage",
         {
-            description: 'Sends a message to a Google Chat space. ' + CHAT_FORMATTING,
+            description: `Sends a message to a Google Chat space. ${CHAT_FORMATTING}`,
             inputSchema: {
                 spaceName: z.string().describe('The name of the space to send the message to (e.g., spaces/AAAAN2J52O8).'),
-                message: z.string().describe('The message to send. ' + CHAT_FORMATTING_SHORT),
+                message: z.string().describe(`The message to send. ${CHAT_FORMATTING_SHORT}`),
             }
         },
         chatService.sendMessage
@@ -483,10 +483,10 @@ async function main() {
     server.registerTool(
         "chat.sendDm",
         {
-            description: 'Sends a direct message to a user. ' + CHAT_FORMATTING,
+            description: `Sends a direct message to a user. ${CHAT_FORMATTING}`,
             inputSchema: {
                 email: z.string().email().describe('The email address of the user to send the message to.'),
-                message: z.string().describe('The message to send. ' + CHAT_FORMATTING_SHORT),
+                message: z.string().describe(`The message to send. ${CHAT_FORMATTING_SHORT}`),
             }
         },
         chatService.sendDm

--- a/workspace-server/src/utils/formatting/constants.ts
+++ b/workspace-server/src/utils/formatting/constants.ts
@@ -5,6 +5,7 @@ export const CHAT_FORMATTING_SHORT = [
   '<url|text> links, <users/{user}> mentions.',
   'No nested lists: use "- -- child" for depth.',
   'Convert: **bold** → *bold*, *italic* → _italic_, [text](url) → <url|text>.',
+  '# headings and > blockquotes are also unsupported syntax.',
 ].join(' ');
 
 export const CHAT_FORMATTING = `
@@ -22,4 +23,6 @@ Unsupported (convert these):
 - **double asterisks** for bold
 - [text](url) markdown links
 - Nested lists (flatten with dashes: "- parent", "- -- child")
+- # headings
+- > blockquotes
 `.trim();


### PR DESCRIPTION
Update `chat.sendMessage` and `chat.sendDm` tool descriptions to document Google Chat's supported text formatting syntax, helping LLMs generate properly formatted messages.

Partially addresses https://github.com/gemini-cli-extensions/workspace/issues/58 (Chat formatting task).

Changes:
- Add CHAT_FORMATTING constant in src/utils/formatting/constants.ts
- Add CHAT_FORMATTING_SHORT for parameter descriptions
- Refactor tool descriptions to use shared constants

Testing:
- Manual test: LLM converts `**bold**` and `__bold__` to `*bold* `
- Manual test: LLM converts `*italic*` to `_italic_`
- Manual test: LLM converts `[text](url)` to `<url|text>`
- Manual test: LLM flattens nested list items, but prefixes the list items with dashes to indicate depth (e.g., "- parent", "- -- child", "- --- grandchild")

Supported syntax:
```
- *bold* (single asterisks, not **)
- _italic_
- ~strikethrough~
- `inline code` and ```code blocks```
- Bulleted lists ("* " or "- " at line start)
- Links: <url|display text> (not [text](url))
- User mentions: <users/{user}>
```
Unsupported syntax (must be converted or avoided):
```
- **double asterisks** for bold
- # headings
- [text](url) markdown links
- > blockquotes
```