### PR TITLE
fix(chat): update WORKSPACE-Context.md with Chat-specific formatting instructions

### DIFF
--- a/workspace-server/WORKSPACE-Context.md
+++ b/workspace-server/WORKSPACE-Context.md
@@ -135,6 +135,31 @@ When asked about "next meeting" or "today's schedule":
 2. **Download**: Use `gmail.downloadAttachment` with the specific `messageId` and `attachmentId`.
 3. **Absolute Paths**: Always provide an **absolute path** for the `localPath` argument (e.g., `/Users/username/Downloads/file.pdf`). Relative paths will be rejected for security.
 
+## 💬 Chat Guidelines
+
+Google Chat uses a specific subset of Markdown. Ensure messages sent to Chat use
+the syntax supported by Chat, and convert any unsupported syntax to a supported
+syntax.
+
+### Supported Formatting
+
+- *bold* (single asterisks)
+- _italic_ (single underscores)
+- ~strikethrough~
+- `inline code`
+- ```code blocks```
+- Bulleted lists ("* " or "- " at line start)
+- Links: <url|text>
+- User mentions: <users/{user}>
+
+### Unsupported (convert these)
+
+- **double asterisks** for bold (convert to *single asterisks*)
+- [text](url) markdown links (convert to <url|text>)
+- Nested lists (flatten with dashes: "- parent", "- -- child")
+- # headings (convert to *bold* text)
+- > blockquotes (preserve the `>` characters, do not remove them)
+
 ## 📄 Docs, Sheets, and Slides
 
 ### Format Selection (Sheets)


### PR DESCRIPTION
Partially addresses
https://github.com/gemini-cli-extensions/workspace/issues/58 (Chat formatting task).

Testing:
- Manual test: LLM converts `**bold**` and `__bold__` to `*bold* `
- Manual test: LLM converts `*italic*` to `_italic_`
- Manual test: LLM converts `[text](url)` to `<url|text>`
- Manual test: LLM flattens nested list items, but prefixes the list items with dashes to indicate depth (e.g., "- parent", "- -- child", "- --- grandchild")

Supported syntax:
```
- *bold* (single asterisks, not **)
- _italic_
- ~strikethrough~
- `inline code` and ```code blocks```
- Bulleted lists ("* " or "- " at line start)
- Links: <url|display text> (not [text](url))
- User mentions: <users/{user}>
```
Unsupported syntax (must be converted or avoided):
```
- **double asterisks** for bold
- # headings
- [text](url) markdown links
- > blockquotes
```