### PR TITLE
feat(gmail): add createLabel tool

### DIFF
--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -672,6 +672,17 @@ There are a list of system labels that can be modified on a message:
         gmailService.listLabels
     );
 
+    server.registerTool(
+        "gmail.createLabel",
+        {
+            description: 'Create a new Gmail label. Labels help organize emails into categories.',
+            inputSchema: {
+                name: z.string().describe('The display name of the label.'),
+            }
+        },
+        gmailService.createLabel
+    );
+
     // Time tools
     server.registerTool(
         "time.getCurrentDate",

--- a/workspace-server/src/services/GmailService.ts
+++ b/workspace-server/src/services/GmailService.ts
@@ -436,6 +436,43 @@ export class GmailService {
         }
     }
 
+    public createLabel = async ({ name }: { name: string }) => {
+        try {
+            logToFile(`Creating Gmail label: ${name}`);
+            
+            const gmail = await this.getGmailClient();
+            
+            const response = await gmail.users.labels.create({
+                userId: 'me',
+                requestBody: {
+                    name,
+                    labelListVisibility: 'labelShow',
+                    messageListVisibility: 'show',
+                }
+            });
+
+            const label = response.data;
+            
+            logToFile(`Created label: ${label.name} with id: ${label.id}`);
+
+            return {
+                content: [{
+                    type: "text" as const,
+                    text: JSON.stringify({
+                        id: label.id,
+                        name: label.name,
+                        type: label.type,
+                        messageListVisibility: label.messageListVisibility,
+                        labelListVisibility: label.labelListVisibility,
+                        status: 'created'
+                    }, null, 2)
+                }]
+            };
+        } catch (error) {
+            return this.handleError(error, 'gmail.createLabel');
+        }
+    }
+
     private extractAttachmentsAndBody(payload: gmail_v1.Schema$MessagePart, result: { body: string, attachments: GmailAttachment[] } = { body: '', attachments: [] }) {
         if (!payload) return result;
 


### PR DESCRIPTION
## Summary
Adds a simple `gmail.createLabel` tool to create new Gmail labels.

## New Tool
- **`gmail.createLabel`** - Create a new Gmail label by name

## Implementation
- Labels are created with default visibility settings (`labelShow`, `show`)
- Returns label details including id, name, type, and visibility settings

## Files Changed
- `workspace-server/src/services/GmailService.ts` - Added `createLabel` method (+37 lines)
- `workspace-server/src/index.ts` - Registered `gmail.createLabel` tool (+11 lines)

## Notes
- Uses existing `gmail.modify` OAuth scope which covers label management
- Minimal implementation - color and advanced visibility options can be added in follow-up PRs