### PR TITLE
feat: Add support for Google Shared Drives by including `supportsAllDrives` and `includeItemsFromAllDrives` parameters in Drive API calls.

### DIFF
--- a/workspace-server/src/__tests__/services/DriveService.test.ts
+++ b/workspace-server/src/__tests__/services/DriveService.test.ts
@@ -112,6 +112,8 @@ describe('DriveService', () => {
         q: "mimeType='application/vnd.google-apps.folder' and name = 'TestFolder'",
         fields: 'files(id, name)',
         spaces: 'drive',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       expect(JSON.parse(result.content[0].text)).toEqual(mockFolders);
@@ -129,6 +131,12 @@ describe('DriveService', () => {
       });
 
       expect(mockDriveAPI.files.list).toHaveBeenCalledTimes(1);
+      expect(mockDriveAPI.files.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          supportsAllDrives: true,
+          includeItemsFromAllDrives: true,
+        }),
+      );
       expect(JSON.parse(result.content[0].text)).toEqual([]);
     });
 
@@ -162,6 +170,7 @@ describe('DriveService', () => {
           mimeType: 'application/vnd.google-apps.folder',
         },
         fields: 'id, name',
+        supportsAllDrives: true,
       });
 
       expect(JSON.parse(result.content[0].text)).toEqual(mockFolder);
@@ -186,6 +195,7 @@ describe('DriveService', () => {
           parents: ['parent-id'],
         },
         fields: 'id, name',
+        supportsAllDrives: true,
       });
 
       expect(JSON.parse(result.content[0].text)).toEqual(mockFolder);
@@ -237,6 +247,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const responseData = JSON.parse(result.content[0].text);
@@ -277,6 +289,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const responseData = JSON.parse(result.content[0].text);
@@ -312,6 +326,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const responseData = JSON.parse(result.content[0].text);
@@ -346,6 +362,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const responseData = JSON.parse(result.content[0].text);
@@ -379,6 +397,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const responseData = JSON.parse(result.content[0].text);
@@ -411,6 +431,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const responseData = JSON.parse(result.content[0].text);
@@ -467,6 +489,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
     });
 
@@ -489,6 +513,8 @@ describe('DriveService', () => {
         corpus: 'domain',
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
     });
 
@@ -521,6 +547,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
     });
 
@@ -551,6 +579,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const responseData = JSON.parse(result.content[0].text);
@@ -582,6 +612,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const responseData = JSON.parse(result.content[0].text);
@@ -607,6 +639,7 @@ describe('DriveService', () => {
       expect(mockDriveAPI.files.get).toHaveBeenCalledWith({
         fileId: 'file456',
         fields: 'id, name, modifiedTime, viewedByMeTime, mimeType, parents',
+        supportsAllDrives: true,
       });
       expect(mockDriveAPI.files.list).not.toHaveBeenCalled();
 
@@ -634,6 +667,7 @@ describe('DriveService', () => {
       expect(mockDriveAPI.files.get).toHaveBeenCalledWith({
         fileId: 'doc789',
         fields: 'id, name, modifiedTime, viewedByMeTime, mimeType, parents',
+        supportsAllDrives: true,
       });
       expect(mockDriveAPI.files.list).not.toHaveBeenCalled();
 
@@ -687,6 +721,7 @@ describe('DriveService', () => {
       expect(mockDriveAPI.files.get).toHaveBeenCalledWith({
         fileId: 'folder789',
         fields: 'mimeType',
+        supportsAllDrives: true,
       });
       expect(mockDriveAPI.files.list).toHaveBeenCalledWith({
         q: "'folder789' in parents",
@@ -695,6 +730,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const responseData = JSON.parse(result.content[0].text);
@@ -724,10 +761,12 @@ describe('DriveService', () => {
       expect(mockDriveAPI.files.get).toHaveBeenCalledWith({
         fileId: 'file123',
         fields: 'mimeType',
+        supportsAllDrives: true,
       });
       expect(mockDriveAPI.files.get).toHaveBeenCalledWith({
         fileId: 'file123',
         fields: 'id, name, modifiedTime, viewedByMeTime, mimeType, parents',
+        supportsAllDrives: true,
       });
       expect(mockDriveAPI.files.list).not.toHaveBeenCalled();
 
@@ -763,6 +802,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const responseData = JSON.parse(result.content[0].text);
@@ -791,6 +832,8 @@ describe('DriveService', () => {
         corpus: undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const responseData = JSON.parse(result.content[0].text);
@@ -824,10 +867,11 @@ describe('DriveService', () => {
       expect(mockDriveAPI.files.get).toHaveBeenCalledWith({
         fileId: mockFileId,
         fields: 'id, name, mimeType',
+        supportsAllDrives: true,
       });
 
       expect(mockDriveAPI.files.get).toHaveBeenCalledWith(
-        { fileId: mockFileId, alt: 'media' },
+        { fileId: mockFileId, alt: 'media', supportsAllDrives: true },
         { responseType: 'arraybuffer' },
       );
 
@@ -869,6 +913,82 @@ describe('DriveService', () => {
       expect(JSON.parse(result.content[0].text)).toEqual({
         error: 'API Error',
       });
+    });
+  });
+
+  describe('Shared Drive Support', () => {
+    it('findFolder should include shared drive flags', async () => {
+      mockDriveAPI.files.list.mockResolvedValue({ data: { files: [] } });
+
+      await driveService.findFolder({ folderName: 'SharedFolder' });
+
+      expect(mockDriveAPI.files.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          supportsAllDrives: true,
+          includeItemsFromAllDrives: true,
+        }),
+      );
+    });
+
+    it('search should include shared drive flags', async () => {
+      mockDriveAPI.files.list.mockResolvedValue({ data: { files: [] } });
+
+      await driveService.search({ query: 'test' });
+
+      expect(mockDriveAPI.files.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          supportsAllDrives: true,
+          includeItemsFromAllDrives: true,
+        }),
+      );
+    });
+
+    it('createFolder should include supportsAllDrives flag', async () => {
+      mockDriveAPI.files.create.mockResolvedValue({
+        data: { id: 'new-id', name: 'new' },
+      });
+
+      await driveService.createFolder({
+        name: 'New Folder',
+        parentId: 'shared-drive-parent-id',
+      });
+
+      expect(mockDriveAPI.files.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          supportsAllDrives: true,
+        }),
+      );
+    });
+
+    it('downloadFile should include supportsAllDrives flag for metadata and media', async () => {
+      mockDriveAPI.files.get.mockResolvedValueOnce({
+        data: { mimeType: 'text/plain', name: 'test.txt' },
+      });
+      mockDriveAPI.files.get.mockResolvedValueOnce({
+        data: { data: Buffer.from('content') },
+      });
+
+      await driveService.downloadFile({
+        fileId: 'shared-file-id',
+        localPath: 'test.txt',
+      });
+
+      // First call for metadata
+      expect(mockDriveAPI.files.get).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          supportsAllDrives: true,
+        }),
+      );
+
+      // Second call for media
+      expect(mockDriveAPI.files.get).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          supportsAllDrives: true,
+        }),
+        expect.any(Object),
+      );
     });
   });
 });

--- a/workspace-server/src/services/DriveService.ts
+++ b/workspace-server/src/services/DriveService.ts
@@ -44,6 +44,8 @@ export class DriveService {
         q: query,
         fields: 'files(id, name)',
         spaces: 'drive',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       const folders = res.data.files || [];
@@ -97,6 +99,7 @@ export class DriveService {
       const file = await drive.files.create({
         requestBody: fileMetadata,
         fields: 'id, name',
+        supportsAllDrives: true,
       });
 
       logToFile(`Created folder: ${file.data.name} (${file.data.id})`);
@@ -171,7 +174,11 @@ export class DriveService {
 
         if (urlType === 'unknown') {
           try {
-            const file = await drive.files.get({ fileId, fields: 'mimeType' });
+            const file = await drive.files.get({
+              fileId,
+              fields: 'mimeType',
+              supportsAllDrives: true,
+            });
             if (file.data.mimeType === 'application/vnd.google-apps.folder') {
               isFolder = true;
             }
@@ -194,6 +201,7 @@ export class DriveService {
               fileId: fileId,
               fields:
                 'id, name, modifiedTime, viewedByMeTime, mimeType, parents',
+              supportsAllDrives: true,
             });
             return {
               content: [
@@ -295,6 +303,8 @@ export class DriveService {
         corpus: corpus as 'user' | 'domain' | undefined,
         fields:
           'nextPageToken, files(id, name, modifiedTime, viewedByMeTime, mimeType, parents)',
+        supportsAllDrives: true,
+        includeItemsFromAllDrives: true,
       });
 
       let files = res.data.files || [];
@@ -350,6 +360,7 @@ export class DriveService {
       const metadata = await drive.files.get({
         fileId: fileId,
         fields: 'id, name, mimeType',
+        supportsAllDrives: true,
       });
       const mimeType = metadata.data.mimeType || '';
 
@@ -402,6 +413,7 @@ export class DriveService {
         {
           fileId: fileId,
           alt: 'media',
+          supportsAllDrives: true,
         },
         { responseType: 'arraybuffer' },
       );


### PR DESCRIPTION
Fixes #158 