### PR TITLE
feat: Implement Read Comments and Suggestions Feature

### DIFF
--- a/workspace-server/src/__tests__/services/DocsService.comments.test.ts
+++ b/workspace-server/src/__tests__/services/DocsService.comments.test.ts
@@ -329,17 +329,63 @@ describe('DocsService Comments and Suggestions', () => {
     });
 
     it('should handle API errors gracefully', async () => {
-      mockDocsAPI.documents.get.mockRejectedValue(
-        new Error('Docs API failed'),
-      );
+      mockDocsAPI.documents.get.mockRejectedValue(new Error('Docs API failed'));
 
       const result = await docsService.getSuggestions({
         documentId: 'test-doc-id',
       });
 
+      expect(result.isError).toBe(true);
       expect(result.content[0].type).toBe('text');
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toEqual({ error: 'Docs API failed' });
+    });
+
+    it('should create one suggestion entry per paragraph suggestion ID', async () => {
+      mockDocsAPI.documents.get.mockResolvedValue({
+        data: {
+          body: {
+            content: [
+              {
+                paragraph: {
+                  suggestedParagraphStyleChanges: {
+                    'sug-1': {
+                      paragraphStyle: { namedStyleType: 'HEADING_1' },
+                    },
+                    'sug-2': {
+                      paragraphStyle: { namedStyleType: 'HEADING_2' },
+                    },
+                  },
+                  elements: [
+                    {
+                      textRun: { content: 'Some heading' },
+                      startIndex: 1,
+                      endIndex: 13,
+                    },
+                  ],
+                },
+                startIndex: 1,
+                endIndex: 13,
+              },
+            ],
+          },
+        },
+      });
+
+      const result = await docsService.getSuggestions({
+        documentId: 'test-doc-id',
+      });
+
+      const suggestions = JSON.parse(result.content[0].text);
+      expect(suggestions).toHaveLength(2);
+      const types = suggestions.map((s: any) => s.type);
+      expect(types).toEqual(['paragraphStyleChange', 'paragraphStyleChange']);
+      const ids = suggestions.map((s: any) => s.suggestionIds[0]);
+      expect(ids).toContain('sug-1');
+      expect(ids).toContain('sug-2');
+      const named = suggestions.map((s: any) => s.namedStyleType);
+      expect(named).toContain('HEADING_1');
+      expect(named).toContain('HEADING_2');
     });
 
     it('should handle undefined textRun.content with empty string fallback', async () => {
@@ -382,10 +428,14 @@ describe('DocsService Comments and Suggestions', () => {
         {
           id: 'comment1',
           content: 'This is a comment.',
-          author: { displayName: 'Test User', emailAddress: 'test@example.com' },
+          author: {
+            displayName: 'Test User',
+            emailAddress: 'test@example.com',
+          },
           createdTime: '2025-01-01T00:00:00Z',
           resolved: false,
           quotedFileContent: { value: 'quoted text' },
+          replies: [],
         },
       ];
       mockDriveAPI.comments.list.mockResolvedValue({
@@ -399,6 +449,56 @@ describe('DocsService Comments and Suggestions', () => {
       expect(result.content[0].type).toBe('text');
       const comments = JSON.parse(result.content[0].text);
       expect(comments).toEqual(mockComments);
+    });
+
+    it('should include replies in comment threads', async () => {
+      const mockComments = [
+        {
+          id: 'comment1',
+          content: 'Top-level comment.',
+          author: { displayName: 'Alice', emailAddress: 'alice@example.com' },
+          createdTime: '2025-01-01T00:00:00Z',
+          resolved: false,
+          quotedFileContent: { value: 'some text' },
+          replies: [
+            {
+              id: 'reply1',
+              content: 'Reply to comment.',
+              author: {
+                displayName: 'Bob',
+                emailAddress: 'bob@example.com',
+              },
+              createdTime: '2025-01-02T00:00:00Z',
+            },
+          ],
+        },
+      ];
+      mockDriveAPI.comments.list.mockResolvedValue({
+        data: { comments: mockComments },
+      });
+
+      const result = await docsService.getComments({
+        documentId: 'test-doc-id',
+      });
+
+      expect(result.content[0].type).toBe('text');
+      const comments = JSON.parse(result.content[0].text);
+      expect(comments).toHaveLength(1);
+      expect(comments[0].replies).toHaveLength(1);
+      expect(comments[0].replies[0].id).toBe('reply1');
+      expect(comments[0].replies[0].content).toBe('Reply to comment.');
+    });
+
+    it('should request replies fields in the Drive API call', async () => {
+      mockDriveAPI.comments.list.mockResolvedValue({ data: { comments: [] } });
+
+      await docsService.getComments({ documentId: 'test-doc-id' });
+
+      expect(mockDriveAPI.comments.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fields: expect.stringContaining('replies('),
+        }),
+      );
     });
 
     it('should handle empty comments list', async () => {
@@ -423,6 +523,7 @@ describe('DocsService Comments and Suggestions', () => {
         documentId: 'test-doc-id',
       });
 
+      expect(result.isError).toBe(true);
       expect(result.content[0].type).toBe('text');
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toEqual({ error: 'Comments API failed' });

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -148,7 +148,9 @@ async function main() {
     {
       description: 'Retrieves suggested edits from a Google Doc.',
       inputSchema: {
-        documentId: z.string().describe('The ID of the document to retrieve suggestions from.'),
+        documentId: z
+          .string()
+          .describe('The ID of the document to retrieve suggestions from.'),
       },
     },
     docsService.getSuggestions,
@@ -159,7 +161,9 @@ async function main() {
     {
       description: 'Retrieves comments from a Google Doc.',
       inputSchema: {
-        documentId: z.string().describe('The ID of the document to retrieve comments from.'),
+        documentId: z
+          .string()
+          .describe('The ID of the document to retrieve comments from.'),
       },
     },
     docsService.getComments,

--- a/workspace-server/src/services/DocsService.ts
+++ b/workspace-server/src/services/DocsService.ts
@@ -21,15 +21,39 @@ import {
   processMarkdownLineBreaks,
 } from '../utils/markdownToDocsRequests';
 
-interface DocsSuggestion {
-  type: 'insertion' | 'deletion' | 'styleChange' | 'paragraphStyleChange';
-  text?: string;
-  suggestionIds?: string[];
+interface BaseDocsSuggestion {
+  text: string;
   startIndex?: number;
   endIndex?: number;
-  namedStyleType?: string;
+}
+
+interface DocsInsertionSuggestion extends BaseDocsSuggestion {
+  type: 'insertion';
+  suggestionIds: string[];
+}
+
+interface DocsDeletionSuggestion extends BaseDocsSuggestion {
+  type: 'deletion';
+  suggestionIds: string[];
+}
+
+interface DocsStyleChangeSuggestion extends BaseDocsSuggestion {
+  type: 'styleChange';
+  suggestionIds: string[];
   textStyle?: docs_v1.Schema$TextStyle;
 }
+
+interface DocsParagraphStyleChangeSuggestion extends BaseDocsSuggestion {
+  type: 'paragraphStyleChange';
+  suggestionIds: string[];
+  namedStyleType?: string;
+}
+
+type DocsSuggestion =
+  | DocsInsertionSuggestion
+  | DocsDeletionSuggestion
+  | DocsStyleChangeSuggestion
+  | DocsParagraphStyleChangeSuggestion;
 
 export class DocsService {
   private purify: ReturnType<typeof createDOMPurify>;
@@ -54,11 +78,7 @@ export class DocsService {
     return google.drive({ version: 'v3', ...options });
   }
 
-  public getSuggestions = async ({
-    documentId,
-  }: {
-    documentId: string;
-  }) => {
+  public getSuggestions = async ({ documentId }: { documentId: string }) => {
     logToFile(
       `[DocsService] Starting getSuggestions for document: ${documentId}`,
     );
@@ -71,7 +91,9 @@ export class DocsService {
         fields: 'body',
       });
 
-      const suggestions: DocsSuggestion[] = this._extractSuggestions(res.data.body);
+      const suggestions: DocsSuggestion[] = this._extractSuggestions(
+        res.data.body,
+      );
 
       logToFile(
         `[DocsService] Found ${suggestions.length} suggestions for document: ${id}`,
@@ -92,6 +114,7 @@ export class DocsService {
         `[DocsService] Error during docs.getSuggestions: ${errorMessage}`,
       );
       return {
+        isError: true,
         content: [
           {
             type: 'text' as const,
@@ -117,19 +140,14 @@ export class DocsService {
         if (element.paragraph) {
           // Handle paragraph-level style suggestions
           if (element.paragraph.suggestedParagraphStyleChanges) {
-            const suggestionIds = Object.keys(
+            for (const [suggestionId, suggestion] of Object.entries(
               element.paragraph.suggestedParagraphStyleChanges,
-            );
-            if (suggestionIds.length > 0) {
-              const firstSuggestion =
-                element.paragraph.suggestedParagraphStyleChanges[
-                  suggestionIds[0]
-                ];
+            )) {
               suggestions.push({
                 type: 'paragraphStyleChange',
                 text: this._getParagraphText(element.paragraph),
-                suggestionIds: suggestionIds,
-                namedStyleType: firstSuggestion?.paragraphStyle?.namedStyleType,
+                suggestionIds: [suggestionId],
+                namedStyleType: suggestion?.paragraphStyle?.namedStyleType,
                 startIndex: element.startIndex,
                 endIndex: element.endIndex,
               });
@@ -185,7 +203,9 @@ export class DocsService {
     return suggestions;
   }
 
-  private _getParagraphText(paragraph: docs_v1.Schema$Paragraph | undefined | null): string {
+  private _getParagraphText(
+    paragraph: docs_v1.Schema$Paragraph | undefined | null,
+  ): string {
     if (!paragraph?.elements) {
       return '';
     }
@@ -202,7 +222,7 @@ export class DocsService {
       const res = await drive.comments.list({
         fileId: id,
         fields:
-          'comments(id, content, author(displayName, emailAddress), createdTime, resolved, quotedFileContent(value))',
+          'comments(id, content, author(displayName, emailAddress), createdTime, resolved, quotedFileContent(value), replies(id, content, author(displayName, emailAddress), createdTime))',
       });
 
       const comments = res.data.comments || [];
@@ -223,6 +243,7 @@ export class DocsService {
         error instanceof Error ? error.message : String(error);
       logToFile(`[DocsService] Error during docs.getComments: ${errorMessage}`);
       return {
+        isError: true,
         content: [
           {
             type: 'text' as const,


### PR DESCRIPTION
This commit introduces functionality to read comments and suggestions from Google Docs using the existing DocsService. The implementation leverages the already present getComments and getSuggestions methods within the service.

Fixes: #200

This change was implemented using Gemini CLI and Gemini models.