### PR TITLE
Security: Prevent Chat Query Injection

### DIFF
--- a/workspace-server/src/services/ChatService.ts
+++ b/workspace-server/src/services/ChatService.ts
@@ -233,7 +233,9 @@ export class ChatService {
       const filters: string[] = [];
 
       if (threadName) {
-        filters.push(`thread.name = "${threadName}"`);
+        // Sanitize thread name to prevent query injection
+        const safeThreadName = threadName.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+        filters.push(`thread.name = "${safeThreadName}"`);
       }
 
       if (unreadOnly) {


### PR DESCRIPTION
This PR fixes a query injection vulnerability in `ChatService.getMessages` by sanitizing the `threadName` parameter.