### PR TITLE
docs: document token storage locations (fixes #243)

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -211,7 +211,7 @@ Use `--force` to re-authenticate if credentials already exist.
 
 The extension uses a **hybrid storage strategy** for OAuth credentials. It first
 attempts to use the OS-level secure storage (via the
-[keytar](https://github.com/nicedoc/keytar) library). If the keychain is
+[keytar](https://github.com/atom/node-keytar) library). If the keychain is
 unavailable, it falls back to AES-256-GCM encrypted file storage.
 
 Credentials are stored under the service name `gemini-cli-workspace-oauth` with
@@ -219,11 +219,11 @@ the account name `main-account`.
 
 #### OS Keychain (Primary)
 
-| Platform  | Backend                          | How to find stored credentials                                                                                                |
-| --------- | -------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
-| **macOS** | Keychain Access                  | Open **Keychain Access** → search for `gemini-cli-workspace-oauth`                                                            |
-| **Windows** | Windows Credential Manager     | Start Menu → search **Credential Manager** → **Windows Credentials** → **Generic Credentials** → `gemini-cli-workspace-oauth` |
-| **Linux** | GNOME Keyring / KWallet (`libsecret`) | Use `secret-tool search service gemini-cli-workspace-oauth` or your desktop's keyring manager                           |
+| Platform    | Backend                               | How to find stored credentials                                                                                                |
+| ----------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| **macOS**   | Keychain Access                       | Open **Keychain Access** → search for `gemini-cli-workspace-oauth`                                                            |
+| **Windows** | Windows Credential Manager            | Start Menu → search **Credential Manager** → **Windows Credentials** → **Generic Credentials** → `gemini-cli-workspace-oauth` |
+| **Linux**   | GNOME Keyring / KWallet (`libsecret`) | Use `secret-tool search service gemini-cli-workspace-oauth` or your desktop's keyring manager                                 |
 
 #### Encrypted File Fallback
 
@@ -231,14 +231,14 @@ When the OS keychain is not available (e.g., headless servers, containers, or CI
 environments), the extension stores credentials in an encrypted file within the
 extension's installation directory:
 
-| File                                  | Purpose                                              |
-| ------------------------------------- | ---------------------------------------------------- |
-| `gemini-cli-workspace-token.json`     | AES-256-GCM encrypted token data                     |
-| `.gemini-cli-workspace-master-key`    | 256-bit master key used to derive the encryption key  |
+| File                               | Purpose                                              |
+| ---------------------------------- | ---------------------------------------------------- |
+| `gemini-cli-workspace-token.json`  | AES-256-GCM encrypted token data                     |
+| `.gemini-cli-workspace-master-key` | 256-bit master key used to derive the encryption key |
 
-Both files are created with restrictive permissions (`0o600` / `0o700`). The
-encryption key is derived from the master key using `scrypt` with a
-machine-specific salt.
+Both files are created with restrictive permissions (`0o600`) and their
+containing directory with `0o700`. The encryption key is derived from the master
+key using `scrypt` with a machine-specific salt.
 
 #### Forcing File Storage
 


### PR DESCRIPTION
## Summary

Adds a **Token Storage** section to `docs/development.md` documenting where OAuth credentials are stored.

### What's documented

- **Hybrid storage strategy** — keychain-first with encrypted file fallback
- **Per-platform keychain locations** — macOS (Keychain Access), Windows (Credential Manager), Linux (GNOME Keyring / KWallet)
- **Encrypted file fallback** — `gemini-cli-workspace-token.json` + `.gemini-cli-workspace-master-key`
- **`GEMINI_CLI_WORKSPACE_FORCE_FILE_STORAGE`** env var to force file-based storage

Fixes #243