### PR TITLE
feat: Add Calendar skill and consolidate calendar guidance

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -211,7 +211,7 @@ Use `--force` to re-authenticate if credentials already exist.
 
 The extension uses a **hybrid storage strategy** for OAuth credentials. It first
 attempts to use the OS-level secure storage (via the
-[keytar](https://github.com/nicedoc/keytar) library). If the keychain is
+[keytar](https://github.com/atom/node-keytar) library). If the keychain is
 unavailable, it falls back to AES-256-GCM encrypted file storage.
 
 Credentials are stored under the service name `gemini-cli-workspace-oauth` with
@@ -236,9 +236,9 @@ extension's installation directory:
 | `gemini-cli-workspace-token.json`  | AES-256-GCM encrypted token data                     |
 | `.gemini-cli-workspace-master-key` | 256-bit master key used to derive the encryption key |
 
-Both files are created with restrictive permissions (`0o600` / `0o700`). The
-encryption key is derived from the master key using `scrypt` with a
-machine-specific salt.
+Both files are created with restrictive permissions (`0o600`) and their
+containing directory with `0o700`. The encryption key is derived from the master
+key using `scrypt` with a machine-specific salt.
 
 #### Forcing File Storage
 

--- a/skills/calendar/SKILL.md
+++ b/skills/calendar/SKILL.md
@@ -1,0 +1,180 @@
+---
+name: calendar
+description: >
+  CRITICAL: You MUST activate this skill BEFORE creating, querying, or managing
+  calendar events. Always trigger this skill as the first step when the user
+  mentions "calendar", "schedule", "meeting", "event", or checking availability.
+  Contains strict behavioral mandates that override default calendar behavior.
+---
+
+# Google Calendar Expert
+
+You are an expert at managing schedules and events through the Google Calendar
+API. Follow these guidelines when helping users with calendar tasks.
+
+## Timezone-First Workflow
+
+**Always establish the user's timezone before any calendar operation:**
+
+1. Call `time.getTimeZone()` (or `time.getCurrentTime()`) to get the user's
+   local timezone
+2. Use this timezone for all time displays and event creation
+3. Always include the timezone abbreviation (EST, PST, etc.) when showing times
+
+> **Important:** ISO 8601 datetimes sent to the API must include a timezone
+> offset (e.g., `2025-01-15T10:30:00-05:00`) or use UTC (`Z`). Never send "bare"
+> datetimes without an offset.
+
+## Understanding "Next Meeting"
+
+When asked about "next meeting", "today's schedule", or similar queries:
+
+1. **Fetch the full day's context** — Use `calendar.listEvents` with start of
+   day (`00:00:00`) to end of day (`23:59:59`) in the user's timezone
+2. **Filter by response status** — Only show meetings where the user has:
+   - Accepted the invitation
+   - Not yet responded (needs to decide)
+   - **DO NOT** show declined meetings unless explicitly requested
+3. **Compare with current time** — Identify meetings relative to now
+4. **Handle edge cases**:
+   - If a meeting is in progress, mention it first
+   - "Next" means the first meeting after the current time
+   - Keep the full day context for follow-up questions
+
+## Meeting Response Filtering
+
+Use the `attendeeResponseStatus` parameter on `calendar.listEvents` to filter
+events by the user's response:
+
+| Default Behavior      | Show Only                          |
+| :-------------------- | :--------------------------------- |
+| Standard schedule     | Accepted and pending (needsAction) |
+| "Show all meetings"   | Include declined                   |
+| "What did I decline?" | Filter to declined only            |
+
+This respects the user's time by not cluttering their schedule with irrelevant
+meetings.
+
+## Creating Events
+
+Use `calendar.createEvent` to add new events. **Always preview the event before
+creating it and wait for user confirmation.**
+
+### Preview Format
+
+```
+I'll create this event:
+
+📅 Title: Weekly Standup
+📆 Date: January 15, 2025
+🕐 Time: 10:00 AM - 10:30 AM (EST)
+👥 Attendees: alice@example.com, bob@example.com
+📝 Description: Weekly team sync
+
+Should I create this event?
+```
+
+### Key Parameters
+
+- **`calendarId`** — Defaults to primary calendar if omitted. Use
+  `calendar.list` to discover other calendars.
+- **`start` / `end`** — Must include timezone offset in ISO 8601 format (e.g.,
+  `2025-01-15T10:00:00-05:00`)
+- **`attendees`** — Array of email addresses
+- **`sendUpdates`** — Controls email notifications:
+  - `"all"` — Notify all attendees (default when attendees are provided)
+  - `"externalOnly"` — Only notify non-organization attendees
+  - `"none"` — No notifications
+
+### Example
+
+```
+calendar.createEvent({
+  calendarId: "primary",
+  summary: "Weekly Standup",
+  start: { dateTime: "2025-01-15T10:00:00-05:00" },
+  end: { dateTime: "2025-01-15T10:30:00-05:00" },
+  attendees: ["alice@example.com", "bob@example.com"],
+  description: "Weekly team sync",
+  sendUpdates: "all"
+})
+```
+
+## Updating Events
+
+Use `calendar.updateEvent` for modifications. Only the fields you provide will
+be changed — everything else is preserved.
+
+- **Rescheduling**: Update `start` and `end`
+- **Adding attendees**: Provide the full attendee list (existing + new)
+- **Changing title/description**: Update `summary` or `description`
+
+> **Important:** The `attendees` field is a full replacement, not an append. To
+> add a new attendee, include all existing attendees plus the new one.
+
+## Deleting Events
+
+Use `calendar.deleteEvent` to remove an event. **This is a destructive action —
+always confirm with the user before executing.**
+
+| Role      | Effect                                  |
+| :-------- | :-------------------------------------- |
+| Organizer | Cancels the event for **all** attendees |
+| Attendee  | Removes it from **your** calendar only  |
+
+## Responding to Events
+
+Use `calendar.respondToEvent` to accept, decline, or tentatively accept meeting
+invitations:
+
+- **`responseStatus`** — `"accepted"`, `"declined"`, or `"tentative"`
+- **`sendNotification`** — Whether to notify the organizer (default: `true`)
+- **`responseMessage`** — Optional message to include with your response
+
+```
+calendar.respondToEvent({
+  eventId: "abc123",
+  responseStatus: "accepted",
+  sendNotification: true,
+  responseMessage: "Looking forward to it!"
+})
+```
+
+## Finding Free Time
+
+Use `calendar.findFreeTime` to find available slots across multiple people's
+calendars. This is ideal for scheduling new meetings.
+
+- **`attendees`** — Email addresses of all participants
+- **`timeMin` / `timeMax`** — The search window (ISO 8601 with timezone)
+- **`duration`** — Meeting length in minutes
+
+```
+calendar.findFreeTime({
+  attendees: ["alice@example.com", "bob@example.com"],
+  timeMin: "2025-01-15T09:00:00-05:00",
+  timeMax: "2025-01-17T17:00:00-05:00",
+  duration: 30
+})
+```
+
+## Working with Multiple Calendars
+
+Users may have multiple calendars (personal, work, shared team calendars).
+
+1. Use `calendar.list` to discover all available calendars
+2. Pass the appropriate `calendarId` to other tools
+3. If no `calendarId` is provided, tools default to the **primary** calendar
+
+## Tool Quick Reference
+
+| Tool                      | Action                      | Key Parameters                                    |
+| :------------------------ | :-------------------------- | :------------------------------------------------ |
+| `calendar.list`           | List all calendars          | _(none)_                                          |
+| `calendar.listEvents`     | List events                 | `calendarId`, `timeMin`, `timeMax`                |
+| `calendar.getEvent`       | Get event details           | `eventId`, `calendarId`                           |
+| `calendar.createEvent`    | Create a new event          | `calendarId`, `summary`, `start`, `end`           |
+| `calendar.updateEvent`    | Modify an existing event    | `eventId`, `summary`, `start`, `end`, `attendees` |
+| `calendar.deleteEvent`    | Delete an event             | `eventId`, `calendarId`                           |
+| `calendar.respondToEvent` | Accept/decline an invite    | `eventId`, `responseStatus`                       |
+| `calendar.findFreeTime`   | Find available meeting time | `attendees`, `timeMin`, `timeMax`, `duration`     |

--- a/workspace-server/WORKSPACE-Context.md
+++ b/workspace-server/WORKSPACE-Context.md
@@ -82,55 +82,6 @@ When creating documents in specific folders:
 2. Then move it to the folder (if specified)
 3. Confirm successful completion
 
-### Calendar Scheduling Workflow
-
-1. Get user's timezone with `time.getTimeZone()`
-2. Check availability with `calendar.listEvents()`
-3. Create event with proper timezone handling
-4. Always show times in user's local timezone
-
-### Event Deletion
-
-When using `calendar.deleteEvent`:
-
-- This is a destructive action that permanently removes the event.
-- For organizers, this cancels the event for all attendees.
-- For attendees, this only removes it from their own calendar.
-- Always confirm with the user before executing a deletion.
-
-## 📅 Calendar Best Practices
-
-### Understanding "Next Meeting"
-
-When asked about "next meeting" or "today's schedule":
-
-1. **Fetch the full day's context** - Use start of day (00:00:00) to end of day
-   (23:59:59)
-2. **Filter by response status** - Only show meetings where the user has:
-   - Accepted the invitation
-   - Not yet responded (needs to decide)
-   - DO NOT show declined meetings unless explicitly requested
-3. **Compare with current time** - Identify meetings relative to now
-4. **Handle edge cases**:
-   - If a meeting is in progress, mention it first
-   - "Next" means the first meeting after current time
-   - Keep full day context for follow-up questions
-
-### Meeting Response Filtering
-
-- **Default behavior**: Show only accepted and pending meetings
-- **Declined meetings**: Exclude unless user asks "show me all meetings" or
-  "including declined"
-- **Use `attendeeResponseStatus`** parameter to filter appropriately
-- This respects the user's time by not cluttering their schedule with irrelevant
-  meetings
-
-### Timezone Management
-
-- Always display times in the user's timezone
-- Convert all times appropriately before display
-- Include timezone abbreviation (EST, PST, etc.) for clarity
-
 ## 📄 Docs, Sheets, and Slides
 
 ### Format Selection (Sheets)
@@ -238,9 +189,8 @@ Choose output format based on use case:
 
 ### Google Calendar
 
-- Event creation requires both start and end times
-- Support for attendee management
-- Response status filtering available
+- See the **Calendar skill** for detailed guidance on timezone handling, meeting
+  queries, event management, responding to invitations, and scheduling.
 
 ### Gmail
 


### PR DESCRIPTION
## Summary

Add a new Calendar skill following the same pattern as the existing Gmail, Chat, and Docs skills. Calendar-specific content has been moved from `WORKSPACE-Context.md` into the dedicated skill for consistency.

## Changes

### New: `skills/calendar/SKILL.md`
Comprehensive behavioral guidance for all 8 calendar tools:
- **Timezone-first workflow** — always establish timezone before calendar operations
- **Meeting queries** — "next meeting" handling, full-day context, response status filtering
- **Event CRUD** — create, update, delete with previews and confirmations
- **Invitation responses** — accept/decline/tentative with notifications
- **Free time scheduling** — find available slots across multiple attendees
- **Multiple calendars** — discover and target specific calendars
- **Tool quick reference** — all 8 tools with key parameters at a glance

### Modified: `workspace-server/WORKSPACE-Context.md`
Removed calendar-specific sections now covered by the skill:
- Calendar Scheduling Workflow (from Multi-Tool Workflows)
- Event Deletion (from Multi-Tool Workflows)
- Entire "📅 Calendar Best Practices" section
- Google Calendar service nuances → replaced with skill cross-reference (matching Docs/Gmail/Chat pattern)

## Testing
- ✅ Format (`prettier`)
- ✅ Lint (`eslint`)
- ✅ All 389 tests passing