### PR TITLE
fix(docs): polish getSuggestions/getComments and update skill docs

### DIFF
--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -223,6 +223,38 @@ Use `docs.find` to search by title. Supports pagination with `pageToken`.
 Use `docs.move` to move a document to a named folder. If multiple folders share
 the same name, the first match is used.
 
+## Comments & Suggestions
+
+### Reading Comments
+
+Use `docs.getComments` to retrieve all comments on a document:
+
+- Returns comment threads with author, content, timestamp, and resolution status
+- Includes **threaded replies** with author, content, timestamp, and action
+  (e.g., `resolve`, `reopen`)
+- Includes **quoted file content** showing what text the comment is anchored to
+
+```
+docs.getComments({ documentId: "doc-id" })
+```
+
+### Reading Suggestions
+
+Use `docs.getSuggestions` to retrieve suggested edits from a document:
+
+- **Insertions** — text proposed for addition (`suggestedInsertionIds`)
+- **Deletions** — text proposed for removal (`suggestedDeletionIds`)
+- **Style changes** — text formatting changes (bold, italic, etc.)
+- **Paragraph style changes** — heading level changes (e.g., NORMAL_TEXT →
+  HEADING_2)
+
+Each suggestion includes the affected text, suggestion IDs, and start/end
+indices.
+
+```
+docs.getSuggestions({ documentId: "doc-id" })
+```
+
 ## ID Handling
 
 - All tools accept Google Drive URLs directly — no manual ID extraction needed

--- a/workspace-server/src/__tests__/services/DocsService.comments.test.ts
+++ b/workspace-server/src/__tests__/services/DocsService.comments.test.ts
@@ -20,11 +20,6 @@ import { google } from 'googleapis';
 // Mock the googleapis module
 jest.mock('googleapis');
 jest.mock('../../utils/logger');
-jest.mock('dompurify', () => {
-  return jest.fn().mockImplementation(() => ({
-    sanitize: jest.fn((content) => content),
-  }));
-});
 
 describe('DocsService Comments and Suggestions', () => {
   let docsService: DocsService;
@@ -527,6 +522,58 @@ describe('DocsService Comments and Suggestions', () => {
       expect(result.content[0].type).toBe('text');
       const parsed = JSON.parse(result.content[0].text);
       expect(parsed).toEqual({ error: 'Comments API failed' });
+    });
+
+    it('should return resolved comments with reply actions', async () => {
+      const mockComments = [
+        {
+          id: 'comment1',
+          content: 'Please fix this typo.',
+          author: {
+            displayName: 'Alice',
+            emailAddress: 'alice@example.com',
+          },
+          createdTime: '2025-01-01T00:00:00Z',
+          resolved: true,
+          quotedFileContent: { value: 'teh' },
+          replies: [
+            {
+              id: 'reply1',
+              content: 'Fixed!',
+              author: {
+                displayName: 'Bob',
+                emailAddress: 'bob@example.com',
+              },
+              createdTime: '2025-01-02T00:00:00Z',
+              action: 'resolve',
+            },
+          ],
+        },
+      ];
+      mockDriveAPI.comments.list.mockResolvedValue({
+        data: { comments: mockComments },
+      });
+
+      const result = await docsService.getComments({
+        documentId: 'test-doc-id',
+      });
+
+      const comments = JSON.parse(result.content[0].text);
+      expect(comments).toHaveLength(1);
+      expect(comments[0].resolved).toBe(true);
+      expect(comments[0].replies[0].action).toBe('resolve');
+    });
+
+    it('should request action field in replies', async () => {
+      mockDriveAPI.comments.list.mockResolvedValue({ data: { comments: [] } });
+
+      await docsService.getComments({ documentId: 'test-doc-id' });
+
+      expect(mockDriveAPI.comments.list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          fields: expect.stringContaining('action'),
+        }),
+      );
     });
   });
 });

--- a/workspace-server/src/services/DocsService.ts
+++ b/workspace-server/src/services/DocsService.ts
@@ -145,9 +145,10 @@ export class DocsService {
                 type: 'paragraphStyleChange',
                 text: this._getParagraphText(element.paragraph),
                 suggestionIds: [suggestionId],
-                namedStyleType: suggestion?.paragraphStyle?.namedStyleType,
-                startIndex: element.startIndex,
-                endIndex: element.endIndex,
+                namedStyleType:
+                  suggestion?.paragraphStyle?.namedStyleType ?? undefined,
+                startIndex: element.startIndex ?? undefined,
+                endIndex: element.endIndex ?? undefined,
               });
             }
           }
@@ -157,8 +158,8 @@ export class DocsService {
             if (pElement.textRun) {
               const baseSuggestion = {
                 text: pElement.textRun.content || '',
-                startIndex: pElement.startIndex,
-                endIndex: pElement.endIndex,
+                startIndex: pElement.startIndex ?? undefined,
+                endIndex: pElement.endIndex ?? undefined,
               };
 
               if (pElement.textRun.suggestedInsertionIds) {
@@ -220,7 +221,7 @@ export class DocsService {
       const res = await drive.comments.list({
         fileId: id,
         fields:
-          'comments(id, content, author(displayName, emailAddress), createdTime, resolved, quotedFileContent(value), replies(id, content, author(displayName, emailAddress), createdTime))',
+          'comments(id, content, author(displayName, emailAddress), createdTime, resolved, quotedFileContent(value), replies(id, content, author(displayName, emailAddress), createdTime, action))',
       });
 
       const comments = res.data.comments || [];


### PR DESCRIPTION
Follow-up to PR #201 addressing remaining review suggestions.

## Changes
- **Add `action` field** to `getComments` reply fields for resolution tracking (resolve/reopen)
- **Fix null/undefined type mismatches** in `_extractSuggestions` using `?? undefined`
- **Remove stale `dompurify` mock** from test file (dompurify was removed from the project)
- **Add tests** for resolved comments with reply actions (2 new test cases)
- **Update Docs skill** (`skills/docs/SKILL.md`) with Comments & Suggestions documentation

## Verification
- Build: ✅
- Tests: 406/406 pass (2 new)
- Lint: ✅
- Format: ✅