### PR TITLE
feat: parse rich smart chips (person, date, rich link) in Google Docs

### DIFF
--- a/workspace-server/src/__tests__/services/DocsService.test.ts
+++ b/workspace-server/src/__tests__/services/DocsService.test.ts
@@ -736,63 +736,52 @@ describe('DocsService', () => {
       });
     });
 
-    it('should extract text from smart chips (date, person, rich link)', async () => {
-      const mockDoc = {
-        data: {
-          tabs: [
-            {
-              documentTab: {
-                body: {
-                  content: [
-                    {
-                      paragraph: {
-                        elements: [
-                          {
-                            textRun: { content: 'Meeting on ' },
-                          },
-                          {
-                            dateElement: {
-                              dateElementProperties: {
-                                displayText: 'Jan 15, 2025',
-                                timestamp: '1736899200',
-                              },
-                            },
-                          },
-                          {
-                            textRun: { content: ' with ' },
-                          },
-                          {
-                            person: {
-                              personProperties: {
-                                name: 'John Doe',
-                                email: 'john@example.com',
-                              },
-                            },
-                          },
-                          {
-                            textRun: { content: ' - see ' },
-                          },
-                          {
-                            richLink: {
-                              richLinkProperties: {
-                                title: 'Project Plan',
-                                uri: 'https://docs.google.com/document/d/abc123',
-                              },
-                            },
-                          },
-                          {
-                            textRun: { content: '\n' },
-                          },
-                        ],
-                      },
-                    },
-                  ],
-                },
+    /** Helper to wrap paragraph elements in the standard mock doc structure. */
+    const mockDocWithElements = (...elements: Record<string, unknown>[]) => ({
+      data: {
+        tabs: [
+          {
+            documentTab: {
+              body: {
+                content: [{ paragraph: { elements } }],
               },
             },
-          ],
+          },
+        ],
+      },
+    });
+
+    it('should extract text from smart chips (date, person, rich link)', async () => {
+      const mockDoc = mockDocWithElements(
+        { textRun: { content: 'Meeting on ' } },
+        {
+          dateElement: {
+            dateElementProperties: {
+              displayText: 'Jan 15, 2025',
+              timestamp: '1736899200',
+            },
+          },
         },
-      };
+        { textRun: { content: ' with ' } },
+        {
+          person: {
+            personProperties: {
+              name: 'John Doe',
+              email: 'john@example.com',
+            },
+          },
+        },
+        { textRun: { content: ' - see ' } },
+        {
+          richLink: {
+            richLinkProperties: {
+              title: 'Project Plan',
+              uri: 'https://docs.google.com/document/d/abc123',
+            },
+          },
+        },
+        { textRun: { content: '\n' } },
+      );
       mockDocsAPI.documents.get.mockResolvedValue(mockDoc);
 
       const result = await docsService.getText({ documentId: 'test-doc-id' });
@@ -862,26 +851,9 @@ describe('DocsService', () => {
     ])(
       'should fall back correctly when $name',
       async ({ element, expected }) => {
-        const mockDoc = {
-          data: {
-            tabs: [
-              {
-                documentTab: {
-                  body: {
-                    content: [
-                      {
-                        paragraph: {
-                          elements: [element],
-                        },
-                      },
-                    ],
-                  },
-                },
-              },
-            ],
-          },
-        };
-        mockDocsAPI.documents.get.mockResolvedValue(mockDoc);
+        mockDocsAPI.documents.get.mockResolvedValue(
+          mockDocWithElements(element),
+        );
 
         const result = await docsService.getText({
           documentId: 'test-doc-id',

--- a/workspace-server/src/services/DocsService.ts
+++ b/workspace-server/src/services/DocsService.ts
@@ -817,23 +817,15 @@ export class DocsService {
         if (pElement.textRun && pElement.textRun.content) {
           text += pElement.textRun.content;
         } else if (pElement.person?.personProperties) {
-          const { name, email } = pElement.person.personProperties;
-          if (email) {
-            text += `[${name || email}](mailto:${email})`;
-          } else if (name) {
-            text += name;
-          }
+          text += this._renderPersonChip(pElement.person.personProperties);
         } else if (pElement.richLink?.richLinkProperties) {
-          const { title, uri } = pElement.richLink.richLinkProperties;
-          if (uri) {
-            text += `[${title || uri}](${uri})`;
-          } else if (title) {
-            text += title;
-          }
+          text += this._renderRichLinkChip(
+            pElement.richLink.richLinkProperties,
+          );
         } else if (pElement.dateElement?.dateElementProperties) {
-          const { displayText, timestamp } =
-            pElement.dateElement.dateElementProperties;
-          text += displayText || timestamp || '';
+          text += this._renderDateChip(
+            pElement.dateElement.dateElementProperties,
+          );
         }
       });
     } else if (element.table) {
@@ -846,6 +838,29 @@ export class DocsService {
       });
     }
     return text;
+  }
+
+  private _renderPersonChip(props: docs_v1.Schema$PersonProperties): string {
+    const { name, email } = props;
+    if (email) {
+      return `[${name || email}](mailto:${email})`;
+    }
+    return name || '';
+  }
+
+  private _renderRichLinkChip(
+    props: docs_v1.Schema$RichLinkProperties,
+  ): string {
+    const { title, uri } = props;
+    if (uri) {
+      return `[${title || uri}](${uri})`;
+    }
+    return title || '';
+  }
+
+  private _renderDateChip(props: docs_v1.Schema$DateElementProperties): string {
+    const { displayText, timestamp } = props;
+    return displayText || timestamp || '';
   }
 
   public replaceText = async ({


### PR DESCRIPTION
Adds smart chip parsing to the DocsService `getText` method, correctly rendering person, date, and rich link chips as readable text/markdown.

## Changes

**`DocsService.ts`** — `_readStructuralElement` now handles:
- **Person chips** → `[Name](mailto:email)` with fallback to email when name is missing
- **Rich link chips** → `[Title](uri)` with fallback to URI when title is missing
- **Date chips** → `displayText` with fallback to timestamp

**`DocsService.test.ts`** — Added tests for:
- Combined smart chip extraction (all three types in one paragraph)
- Fallback behavior for each chip type using `it.each` (person → email, rich link → URI, date → timestamp)

## Review Items Addressed (from PR #215)
- ✅ Rich link `title || uri` fallback bug fixed
- ✅ Missing fallback test for rich links added
- ✅ Fallback tests refactored to `it.each`  
- ✅ Prettier formatting applied
- ✅ Rebased on main

Closes #215

Co-authored-by: MrwanBaghdad <marwan.nabil@deliveryhero.com>