### PR TITLE
chore: release v0.0.7

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -30,7 +30,6 @@ The extension provides the following tools:
 ### Google Slides
 
 - `slides.getText`: Retrieves the text content of a Google Slides presentation.
-- `slides.find`: Finds Google Slides presentations by searching for a query.
 - `slides.getMetadata`: Gets metadata about a Google Slides presentation.
 - `slides.getImages`: Downloads all images embedded in a Google Slides
   presentation to a local directory.
@@ -42,7 +41,6 @@ The extension provides the following tools:
 - `sheets.getText`: Retrieves the content of a Google Sheets spreadsheet.
 - `sheets.getRange`: Gets values from a specific range in a Google Sheets
   spreadsheet.
-- `sheets.find`: Finds Google Sheets spreadsheets by searching for a query.
 - `sheets.getMetadata`: Gets metadata about a Google Sheets spreadsheet.
 
 ### Google Drive

--- a/docs/index.md
+++ b/docs/index.md
@@ -19,8 +19,6 @@ The extension provides the following tools:
 - `docs.getSuggestions`: Retrieves suggested edits from a Google Doc.
 - `docs.getComments`: Retrieves comments from a Google Doc.
 - `docs.writeText`: Writes text to a Google Doc at a specified position.
-- `docs.find`: Finds Google Docs by searching for a query in their title.
-- `docs.move`: Moves a document to a specified folder.
 - `docs.getText`: Retrieves the text content of a Google Doc.
 - `docs.replaceText`: Replaces all occurrences of a given text with new text in
   a Google Doc.

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -1,5 +1,32 @@
 # Release Notes
 
+## 0.0.7 (2026-03-11)
+
+### Breaking Changes
+
+- **Google Sheets**: Removed `sheets.find` tool. Use `drive.search` with MIME
+  type filter instead (e.g.,
+  `mimeType='application/vnd.google-apps.spreadsheet'`).
+- **Google Slides**: Removed `slides.find` tool. Use `drive.search` with MIME
+  type filter instead (e.g.,
+  `mimeType='application/vnd.google-apps.presentation'`).
+
+### Improvements
+
+- **Skills**: Renamed all skill directories to `google-*` prefix (e.g.,
+  `calendar` → `google-calendar`) to avoid slash command conflicts.
+- **Calendar Skill**: Added explicit `calendarId='primary'` mandate to prevent
+  agents from omitting the required parameter.
+
+### Skills
+
+- **Sheets Skill**: New skill with `drive.search` guidance for finding
+  spreadsheets.
+- **Slides Skill**: New skill with `drive.search` guidance for finding
+  presentations.
+- **Docs Skill**: Updated with `drive.search` guidance and removed stale
+  `docs.find`/`docs.move` references.
+
 ## 0.0.6 (2026-03-08)
 
 ### New Features

--- a/docs/release_notes.md
+++ b/docs/release_notes.md
@@ -25,7 +25,7 @@
 - **Slides Skill**: New skill with `drive.search` guidance for finding
   presentations.
 - **Docs Skill**: Updated with `drive.search` guidance and removed stale
-  `docs.find`/`docs.move` references.
+  `docs.find`/`docs.move` references from skill and documentation.
 
 ## 0.0.6 (2026-03-08)
 

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "google-workspace",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "contextFileName": "workspace-server${/}WORKSPACE-Context.md",
   "mcpServers": {
     "google-workspace": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-workspace-extension",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Google Workspace Server Extension",
   "private": true,
   "bin": {

--- a/workspace-server/package.json
+++ b/workspace-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-server",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Release v0.0.7

### Changes

- Bump version to 0.0.7 across `package.json`, `workspace-server/package.json`, and `gemini-extension.json`
- Add v0.0.7 release notes

### Breaking Changes

- **Google Sheets**: Removed `sheets.find` tool. Use `drive.search` with MIME type filter instead.
- **Google Slides**: Removed `slides.find` tool. Use `drive.search` with MIME type filter instead.

### Improvements

- Skills renamed to `google-*` prefix to avoid slash command conflicts (#274)
- Calendar skill updated with explicit `calendarId='primary'` mandate (#272)
- New Sheets and Slides skills with `drive.search` guidance (#271)
- Cleaned up stale `slides.find`/`sheets.find` references in `docs/index.md`

### Verification

- ✅ All 414 tests pass
- ✅ Prettier formatting clean