### PR TITLE
feat(calendar): add calendar management tools

### DIFF
--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -639,113 +639,6 @@ async function main() {
   );
 
   server.registerTool(
-    'calendar.createCalendar',
-    {
-      description: 'Creates a new calendar.',
-      inputSchema: {
-        summary: z.string().describe('Calendar name/title.'),
-        description: z
-          .string()
-          .optional()
-          .describe('Optional calendar description.'),
-        timeZone: z
-          .string()
-          .optional()
-          .describe('Optional IANA timezone (e.g., America/New_York).'),
-      },
-    },
-    calendarService.createCalendar,
-  );
-
-  server.registerTool(
-    'calendar.createRecurringEvent',
-    {
-      description: 'Creates a recurring event in a calendar.',
-      inputSchema: {
-        calendarId: z
-          .string()
-          .optional()
-          .describe(
-            'The ID of the calendar to create the recurring event in. Defaults to primary.',
-          ),
-        summary: z.string().describe('The summary or title of the event.'),
-        description: z
-          .string()
-          .optional()
-          .describe('The description of the event.'),
-        start: z.object({
-          dateTime: z
-            .string()
-            .describe(
-              'The start time in strict ISO 8601 format with seconds and timezone.',
-            ),
-        }),
-        end: z.object({
-          dateTime: z
-            .string()
-            .describe(
-              'The end time in strict ISO 8601 format with seconds and timezone.',
-            ),
-        }),
-        attendees: z
-          .array(z.string())
-          .optional()
-          .describe('The email addresses of the attendees.'),
-        recurrence: z
-          .array(z.string())
-          .min(1)
-          .describe(
-            'Recurrence rules (e.g., ["RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=10"]).',
-          ),
-        reminders: z
-          .object({
-            useDefault: z.boolean().optional(),
-            overrides: z
-              .array(
-                z.object({
-                  method: z.enum(['email', 'popup']),
-                  minutes: z.number().int().min(0),
-                }),
-              )
-              .optional(),
-          })
-          .optional()
-          .describe('Optional reminder configuration for the recurring event.'),
-      },
-    },
-    calendarService.createRecurringEvent,
-  );
-
-  server.registerTool(
-    'calendar.setEventReminders',
-    {
-      description:
-        'Sets custom reminders for an existing calendar event (or resets to default reminders).',
-      inputSchema: {
-        eventId: z.string().describe('The ID of the event to update reminders for.'),
-        calendarId: z
-          .string()
-          .optional()
-          .describe('The ID of the calendar containing the event.'),
-        useDefault: z
-          .boolean()
-          .optional()
-          .describe('Whether to use default calendar reminders (default: true).'),
-        overrides: z
-          .array(
-            z.object({
-              method: z.enum(['email', 'popup']),
-              minutes: z.number().int().min(0),
-            }),
-          )
-          .optional()
-          .describe('Custom reminder overrides.'),
-      },
-    },
-    calendarService.setEventReminders,
-  );
-
-  server.registerTool(
     'calendar.listEvents',
     {
       description: 'Lists events from a calendar. Defaults to upcoming events.',
@@ -907,12 +800,119 @@ async function main() {
             'The ID of the calendar to delete the event from. Defaults to the primary calendar.',
           ),
       },
-    },
-    calendarService.deleteEvent,
-  );
+     },
+     calendarService.deleteEvent,
+   );
 
-  server.registerTool(
-    'chat.listSpaces',
+   server.registerTool(
+     'calendar.createCalendar',
+     {
+       description: 'Creates a new calendar.',
+       inputSchema: {
+         summary: z.string().describe('Calendar name/title.'),
+         description: z
+           .string()
+           .optional()
+           .describe('Optional calendar description.'),
+         timeZone: z
+           .string()
+           .optional()
+           .describe('Optional IANA timezone (e.g., America/New_York).'),
+       },
+     },
+     calendarService.createCalendar,
+   );
+
+   server.registerTool(
+     'calendar.createRecurringEvent',
+     {
+       description: 'Creates a recurring event in a calendar.',
+       inputSchema: {
+         calendarId: z
+           .string()
+           .optional()
+           .describe(
+             'The ID of the calendar to create the recurring event in. Defaults to primary.',
+           ),
+         summary: z.string().describe('The summary or title of the event.'),
+         description: z
+           .string()
+           .optional()
+           .describe('The description of the event.'),
+         start: z.object({
+           dateTime: z
+             .string()
+             .describe(
+               'The start time in strict ISO 8601 format with seconds and timezone.',
+             ),
+         }),
+         end: z.object({
+           dateTime: z
+             .string()
+             .describe(
+               'The end time in strict ISO 8601 format with seconds and timezone.',
+             ),
+         }),
+         attendees: z
+           .array(z.string())
+           .optional()
+           .describe('The email addresses of the attendees.'),
+         recurrence: z
+           .array(z.string())
+           .min(1)
+           .describe(
+             'Recurrence rules (e.g., ["RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=10"]).',
+           ),
+         reminders: z
+           .object({
+             useDefault: z.boolean().optional(),
+             overrides: z
+               .array(
+                 z.object({
+                   method: z.enum(['email', 'popup']),
+                   minutes: z.number().min(0),
+                 }),
+               )
+               .optional(),
+           })
+           .optional()
+           .describe('Optional reminder configuration for the recurring event.'),
+       },
+     },
+     calendarService.createRecurringEvent,
+   );
+
+   server.registerTool(
+     'calendar.setEventReminders',
+     {
+       description:
+         'Sets custom reminders for an existing calendar event (or resets to default reminders).',
+       inputSchema: {
+         eventId: z.string().describe('The ID of the event to update reminders for.'),
+         calendarId: z
+           .string()
+           .optional()
+           .describe('The ID of the calendar containing the event.'),
+         useDefault: z
+           .boolean()
+           .optional()
+           .describe('Whether to use default calendar reminders (default: true).'),
+         overrides: z
+           .array(
+             z.object({
+               method: z.enum(['email', 'popup']),
+               minutes: z.number().min(0),
+             }),
+           )
+           .optional()
+           .describe('Custom reminder overrides.'),
+       },
+     },
+     calendarService.setEventReminders,
+   );
+
+   server.registerTool(
+     'chat.listSpaces',
     {
       description: 'Lists the spaces the user is a member of.',
       inputSchema: {},

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -639,6 +639,113 @@ async function main() {
   );
 
   server.registerTool(
+    'calendar.createCalendar',
+    {
+      description: 'Creates a new calendar.',
+      inputSchema: {
+        summary: z.string().describe('Calendar name/title.'),
+        description: z
+          .string()
+          .optional()
+          .describe('Optional calendar description.'),
+        timeZone: z
+          .string()
+          .optional()
+          .describe('Optional IANA timezone (e.g., America/New_York).'),
+      },
+    },
+    calendarService.createCalendar,
+  );
+
+  server.registerTool(
+    'calendar.createRecurringEvent',
+    {
+      description: 'Creates a recurring event in a calendar.',
+      inputSchema: {
+        calendarId: z
+          .string()
+          .optional()
+          .describe(
+            'The ID of the calendar to create the recurring event in. Defaults to primary.',
+          ),
+        summary: z.string().describe('The summary or title of the event.'),
+        description: z
+          .string()
+          .optional()
+          .describe('The description of the event.'),
+        start: z.object({
+          dateTime: z
+            .string()
+            .describe(
+              'The start time in strict ISO 8601 format with seconds and timezone.',
+            ),
+        }),
+        end: z.object({
+          dateTime: z
+            .string()
+            .describe(
+              'The end time in strict ISO 8601 format with seconds and timezone.',
+            ),
+        }),
+        attendees: z
+          .array(z.string())
+          .optional()
+          .describe('The email addresses of the attendees.'),
+        recurrence: z
+          .array(z.string())
+          .min(1)
+          .describe(
+            'Recurrence rules (e.g., ["RRULE:FREQ=WEEKLY;BYDAY=MO;COUNT=10"]).',
+          ),
+        reminders: z
+          .object({
+            useDefault: z.boolean().optional(),
+            overrides: z
+              .array(
+                z.object({
+                  method: z.enum(['email', 'popup']),
+                  minutes: z.number().int().min(0),
+                }),
+              )
+              .optional(),
+          })
+          .optional()
+          .describe('Optional reminder configuration for the recurring event.'),
+      },
+    },
+    calendarService.createRecurringEvent,
+  );
+
+  server.registerTool(
+    'calendar.setEventReminders',
+    {
+      description:
+        'Sets custom reminders for an existing calendar event (or resets to default reminders).',
+      inputSchema: {
+        eventId: z.string().describe('The ID of the event to update reminders for.'),
+        calendarId: z
+          .string()
+          .optional()
+          .describe('The ID of the calendar containing the event.'),
+        useDefault: z
+          .boolean()
+          .optional()
+          .describe('Whether to use default calendar reminders (default: true).'),
+        overrides: z
+          .array(
+            z.object({
+              method: z.enum(['email', 'popup']),
+              minutes: z.number().int().min(0),
+            }),
+          )
+          .optional()
+          .describe('Custom reminder overrides.'),
+      },
+    },
+    calendarService.setEventReminders,
+  );
+
+  server.registerTool(
     'calendar.listEvents',
     {
       description: 'Lists events from a calendar. Defaults to upcoming events.',

--- a/workspace-server/src/services/CalendarService.ts
+++ b/workspace-server/src/services/CalendarService.ts
@@ -150,6 +150,19 @@ export class CalendarService {
     return error instanceof Error ? error.message : String(error);
   }
 
+  private createApiErrorResponse(error: unknown, toolName: string) {
+    const errorMessage = this.getErrorMessage(error);
+    logToFile(`Error during ${toolName}: ${errorMessage}`);
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({ error: errorMessage }),
+        },
+      ],
+    };
+  }
+
   private createValidationErrorResponse(error: unknown) {
     const errorMessage =
       error instanceof Error ? this.getErrorMessage(error) : 'Validation failed';
@@ -341,9 +354,7 @@ export class CalendarService {
       });
       return { content: [{ type: 'text' as const, text: JSON.stringify(res.data) }] };
     } catch (error) {
-      const errorMessage = this.getErrorMessage(error);
-      logToFile(`Error during calendar.createCalendar: ${errorMessage}`);
-      return { content: [{ type: 'text' as const, text: JSON.stringify({ error: errorMessage }) }] };
+      return this.createApiErrorResponse(error, 'calendar.createCalendar');
     }
   };
 
@@ -377,9 +388,7 @@ export class CalendarService {
       logToFile(`Successfully created recurring event: ${res.data.id}`);
       return { content: [{ type: 'text' as const, text: JSON.stringify(res.data) }] };
     } catch (error) {
-      const errorMessage = this.getErrorMessage(error);
-      logToFile(`Error during calendar.createRecurringEvent: ${errorMessage}`);
-      return { content: [{ type: 'text' as const, text: JSON.stringify({ error: errorMessage }) }] };
+      return this.createApiErrorResponse(error, 'calendar.createRecurringEvent');
     }
   };
 
@@ -392,9 +401,7 @@ export class CalendarService {
       const res = await calendar.events.patch({ calendarId: finalCalendarId, eventId, requestBody: { reminders: { useDefault, overrides } } });
       return { content: [{ type: 'text' as const, text: JSON.stringify(res.data) }] };
     } catch (error) {
-      const errorMessage = this.getErrorMessage(error);
-      logToFile(`Error during calendar.setEventReminders: ${errorMessage}`);
-      return { content: [{ type: 'text' as const, text: JSON.stringify({ error: errorMessage }) }] };
+      return this.createApiErrorResponse(error, 'calendar.setEventReminders');
     }
   };
 

--- a/workspace-server/src/services/CalendarService.ts
+++ b/workspace-server/src/services/CalendarService.ts
@@ -4,22 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import crypto from 'node:crypto';
 import { calendar_v3, google } from 'googleapis';
 import { logToFile } from '../utils/logger';
 import { gaxiosOptions } from '../utils/GaxiosConfig';
 import { iso8601DateTimeSchema, emailArraySchema } from '../utils/validation';
 import { z } from 'zod';
-
-/**
- * Google Drive file attachment for calendar events.
- * Attachments are fully replaced (not appended) when provided.
- */
-interface EventAttachment {
-  fileUrl: string;
-  title?: string;
-  mimeType?: string;
-}
 
 export interface CreateEventInput {
   calendarId?: string;
@@ -28,9 +17,39 @@ export interface CreateEventInput {
   start: { dateTime: string };
   end: { dateTime: string };
   attendees?: string[];
-  sendUpdates?: 'all' | 'externalOnly' | 'none';
-  addGoogleMeet?: boolean;
-  attachments?: EventAttachment[];
+}
+
+export interface CreateRecurringEventInput {
+  calendarId?: string;
+  summary: string;
+  description?: string;
+  start: { dateTime: string };
+  end: { dateTime: string };
+  attendees?: string[];
+  recurrence: string[];
+  reminders?: {
+    useDefault?: boolean;
+    overrides?: Array<{
+      method: 'email' | 'popup';
+      minutes: number;
+    }>;
+  };
+}
+
+export interface CreateCalendarInput {
+  summary: string;
+  description?: string;
+  timeZone?: string;
+}
+
+export interface SetEventRemindersInput {
+  eventId: string;
+  calendarId?: string;
+  useDefault?: boolean;
+  overrides?: Array<{
+    method: 'email' | 'popup';
+    minutes: number;
+  }>;
 }
 
 export interface ListEventsInput {
@@ -58,8 +77,6 @@ export interface UpdateEventInput {
   start?: { dateTime: string };
   end?: { dateTime: string };
   attendees?: string[];
-  addGoogleMeet?: boolean;
-  attachments?: EventAttachment[];
 }
 
 export interface RespondToEventInput {
@@ -81,37 +98,6 @@ export class CalendarService {
   private primaryCalendarId: string | null = null;
 
   constructor(private authManager: any) {}
-
-  /**
-   * Adds conferenceData and attachments to an event body and its API params.
-   *
-   * IMPORTANT: Attachments are fully REPLACED, not appended. When attachments
-   * are provided, any existing attachments on the event will be removed.
-   */
-  private applyMeetAndAttachments(
-    event: calendar_v3.Schema$Event,
-    params: { conferenceDataVersion?: number; supportsAttachments?: boolean },
-    addGoogleMeet?: boolean,
-    attachments?: EventAttachment[],
-  ): void {
-    if (addGoogleMeet) {
-      event.conferenceData = {
-        createRequest: {
-          requestId: crypto.randomUUID(),
-          conferenceSolutionKey: { type: 'hangoutsMeet' },
-        },
-      };
-      params.conferenceDataVersion = 1;
-    }
-    if (attachments && attachments.length > 0) {
-      event.attachments = attachments.map((a) => ({
-        fileUrl: a.fileUrl,
-        title: a.title,
-        mimeType: a.mimeType,
-      }));
-      params.supportsAttachments = true;
-    }
-  }
 
   private createValidationErrorResponse(error: unknown) {
     const errorMessage =
@@ -142,6 +128,160 @@ export class CalendarService {
       ],
     };
   }
+
+  createRecurringEvent = async (input: CreateRecurringEventInput) => {
+    const {
+      calendarId,
+      summary,
+      description,
+      start,
+      end,
+      attendees,
+      recurrence,
+      reminders,
+    } = input;
+
+    try {
+      iso8601DateTimeSchema.parse(start.dateTime);
+      iso8601DateTimeSchema.parse(end.dateTime);
+      if (attendees) {
+        emailArraySchema.parse(attendees);
+      }
+      if (!recurrence || recurrence.length === 0) {
+        throw new Error('recurrence must contain at least one RRULE string');
+      }
+    } catch (error) {
+      return this.createValidationErrorResponse(error);
+    }
+
+    const finalCalendarId = calendarId || (await this.getPrimaryCalendarId());
+    logToFile(`Creating recurring event in calendar: ${finalCalendarId}`);
+
+    try {
+      const event: calendar_v3.Schema$Event = {
+        summary,
+        description,
+        start,
+        end,
+        attendees: attendees?.map((email) => ({ email })),
+        recurrence,
+      };
+
+      if (reminders) {
+        event.reminders = {
+          useDefault: reminders.useDefault,
+          overrides: reminders.overrides,
+        };
+      }
+
+      const calendar = await this.getCalendar();
+      const res = await calendar.events.insert({
+        calendarId: finalCalendarId,
+        requestBody: event,
+      });
+
+      logToFile(`Successfully created recurring event: ${res.data.id}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(res.data),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logToFile(`Error during calendar.createRecurringEvent: ${errorMessage}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ error: errorMessage }),
+          },
+        ],
+      };
+    }
+  };
+
+  createCalendar = async (input: CreateCalendarInput) => {
+    const { summary, description, timeZone } = input;
+    logToFile(`Creating calendar with summary: ${summary}`);
+
+    try {
+      const calendar = await this.getCalendar();
+      const res = await calendar.calendars.insert({
+        requestBody: {
+          summary,
+          description,
+          timeZone,
+        },
+      });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(res.data),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logToFile(`Error during calendar.createCalendar: ${errorMessage}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ error: errorMessage }),
+          },
+        ],
+      };
+    }
+  };
+
+  setEventReminders = async (input: SetEventRemindersInput) => {
+    const { eventId, calendarId, useDefault = true, overrides } = input;
+
+    const finalCalendarId = calendarId || (await this.getPrimaryCalendarId());
+    logToFile(`Setting reminders for event ${eventId} in ${finalCalendarId}`);
+
+    try {
+      const calendar = await this.getCalendar();
+      const res = await calendar.events.patch({
+        calendarId: finalCalendarId,
+        eventId,
+        requestBody: {
+          reminders: {
+            useDefault,
+            overrides,
+          },
+        },
+      });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(res.data),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logToFile(`Error during calendar.setEventReminders: ${errorMessage}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ error: errorMessage }),
+          },
+        ],
+      };
+    }
+  };
 
   private async getCalendar(): Promise<calendar_v3.Calendar> {
     logToFile('Getting authenticated client for calendar...');
@@ -206,17 +346,7 @@ export class CalendarService {
   };
 
   createEvent = async (input: CreateEventInput) => {
-    const {
-      calendarId,
-      summary,
-      description,
-      start,
-      end,
-      attendees,
-      sendUpdates,
-      addGoogleMeet,
-      attachments,
-    } = input;
+    const { calendarId, summary, description, start, end, attendees } = input;
 
     // Validate datetime formats
     try {
@@ -236,42 +366,19 @@ export class CalendarService {
     logToFile(`Event start: ${start.dateTime}`);
     logToFile(`Event end: ${end.dateTime}`);
     logToFile(`Event attendees: ${attendees?.join(', ')}`);
-    if (addGoogleMeet) logToFile('Adding Google Meet link');
-    if (attachments?.length)
-      logToFile(`Attachments: ${attachments.length} file(s)`);
-
-    // Determine sendUpdates value
-    let finalSendUpdates = sendUpdates;
-    if (finalSendUpdates === undefined) {
-      finalSendUpdates = attendees?.length ? 'all' : 'none';
-    }
-    if (finalSendUpdates) {
-      logToFile(`Sending updates: ${finalSendUpdates}`);
-    }
-
     try {
-      const event: calendar_v3.Schema$Event = {
+      const event = {
         summary,
         description,
         start,
         end,
         attendees: attendees?.map((email) => ({ email })),
       };
-
       const calendar = await this.getCalendar();
-      const insertParams: calendar_v3.Params$Resource$Events$Insert = {
+      const res = await calendar.events.insert({
         calendarId: finalCalendarId,
         requestBody: event,
-        sendUpdates: finalSendUpdates,
-      };
-      this.applyMeetAndAttachments(
-        event,
-        insertParams,
-        addGoogleMeet,
-        attachments,
-      );
-
-      const res = await calendar.events.insert(insertParams);
+      });
       logToFile(`Successfully created event: ${res.data.id}`);
       return {
         content: [
@@ -440,17 +547,8 @@ export class CalendarService {
   };
 
   updateEvent = async (input: UpdateEventInput) => {
-    const {
-      eventId,
-      calendarId,
-      summary,
-      description,
-      start,
-      end,
-      attendees,
-      addGoogleMeet,
-      attachments,
-    } = input;
+    const { eventId, calendarId, summary, description, start, end, attendees } =
+      input;
 
     // Validate datetime formats if provided
     try {
@@ -469,9 +567,6 @@ export class CalendarService {
 
     const finalCalendarId = calendarId || (await this.getPrimaryCalendarId());
     logToFile(`Updating event ${eventId} in calendar: ${finalCalendarId}`);
-    if (addGoogleMeet) logToFile('Adding Google Meet link');
-    if (attachments?.length)
-      logToFile(`Attachments: ${attachments.length} file(s)`);
 
     try {
       const calendar = await this.getCalendar();
@@ -485,19 +580,11 @@ export class CalendarService {
       if (attendees)
         requestBody.attendees = attendees.map((email) => ({ email }));
 
-      const updateParams: calendar_v3.Params$Resource$Events$Update = {
+      const res = await calendar.events.update({
         calendarId: finalCalendarId,
         eventId,
         requestBody,
-      };
-      this.applyMeetAndAttachments(
-        requestBody,
-        updateParams,
-        addGoogleMeet,
-        attachments,
-      );
-
-      const res = await calendar.events.update(updateParams);
+      });
 
       logToFile(`Successfully updated event: ${res.data.id}`);
       return {

--- a/workspace-server/src/services/CalendarService.ts
+++ b/workspace-server/src/services/CalendarService.ts
@@ -4,11 +4,22 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import crypto from 'node:crypto';
 import { calendar_v3, google } from 'googleapis';
 import { logToFile } from '../utils/logger';
 import { gaxiosOptions } from '../utils/GaxiosConfig';
 import { iso8601DateTimeSchema, emailArraySchema } from '../utils/validation';
 import { z } from 'zod';
+
+/**
+ * Google Drive file attachment for calendar events.
+ * Attachments are fully replaced (not appended) when provided.
+ */
+interface EventAttachment {
+  fileUrl: string;
+  title?: string;
+  mimeType?: string;
+}
 
 export interface CreateEventInput {
   calendarId?: string;
@@ -17,39 +28,9 @@ export interface CreateEventInput {
   start: { dateTime: string };
   end: { dateTime: string };
   attendees?: string[];
-}
-
-export interface CreateRecurringEventInput {
-  calendarId?: string;
-  summary: string;
-  description?: string;
-  start: { dateTime: string };
-  end: { dateTime: string };
-  attendees?: string[];
-  recurrence: string[];
-  reminders?: {
-    useDefault?: boolean;
-    overrides?: Array<{
-      method: 'email' | 'popup';
-      minutes: number;
-    }>;
-  };
-}
-
-export interface CreateCalendarInput {
-  summary: string;
-  description?: string;
-  timeZone?: string;
-}
-
-export interface SetEventRemindersInput {
-  eventId: string;
-  calendarId?: string;
-  useDefault?: boolean;
-  overrides?: Array<{
-    method: 'email' | 'popup';
-    minutes: number;
-  }>;
+  sendUpdates?: 'all' | 'externalOnly' | 'none';
+  addGoogleMeet?: boolean;
+  attachments?: EventAttachment[];
 }
 
 export interface ListEventsInput {
@@ -77,6 +58,8 @@ export interface UpdateEventInput {
   start?: { dateTime: string };
   end?: { dateTime: string };
   attendees?: string[];
+  addGoogleMeet?: boolean;
+  attachments?: EventAttachment[];
 }
 
 export interface RespondToEventInput {
@@ -94,10 +77,68 @@ export interface FindFreeTimeInput {
   duration: number;
 }
 
+export interface CreateRecurringEventInput {
+  calendarId?: string;
+  summary: string;
+  description?: string;
+  start: { dateTime: string };
+  end: { dateTime: string };
+  attendees?: string[];
+  recurrence: string[];
+  reminders?: {
+    useDefault?: boolean;
+    overrides?: Array<{ method: 'email' | 'popup'; minutes: number }>;
+  };
+}
+
+export interface CreateCalendarInput {
+  summary: string;
+  description?: string;
+  timeZone?: string;
+}
+
+export interface SetEventRemindersInput {
+  eventId: string;
+  calendarId?: string;
+  useDefault?: boolean;
+  overrides?: Array<{ method: 'email' | 'popup'; minutes: number }>;
+}
+
 export class CalendarService {
   private primaryCalendarId: string | null = null;
 
   constructor(private authManager: any) {}
+
+  /**
+   * Adds conferenceData and attachments to an event body and its API params.
+   *
+   * IMPORTANT: Attachments are fully REPLACED, not appended. When attachments
+   * are provided, any existing attachments on the event will be removed.
+   */
+  private applyMeetAndAttachments(
+    event: calendar_v3.Schema$Event,
+    params: { conferenceDataVersion?: number; supportsAttachments?: boolean },
+    addGoogleMeet?: boolean,
+    attachments?: EventAttachment[],
+  ): void {
+    if (addGoogleMeet) {
+      event.conferenceData = {
+        createRequest: {
+          requestId: crypto.randomUUID(),
+          conferenceSolutionKey: { type: 'hangoutsMeet' },
+        },
+      };
+      params.conferenceDataVersion = 1;
+    }
+    if (attachments && attachments.length > 0) {
+      event.attachments = attachments.map((a) => ({
+        fileUrl: a.fileUrl,
+        title: a.title,
+        mimeType: a.mimeType,
+      }));
+      params.supportsAttachments = true;
+    }
+  }
 
   private createValidationErrorResponse(error: unknown) {
     const errorMessage =
@@ -128,160 +169,6 @@ export class CalendarService {
       ],
     };
   }
-
-  createRecurringEvent = async (input: CreateRecurringEventInput) => {
-    const {
-      calendarId,
-      summary,
-      description,
-      start,
-      end,
-      attendees,
-      recurrence,
-      reminders,
-    } = input;
-
-    try {
-      iso8601DateTimeSchema.parse(start.dateTime);
-      iso8601DateTimeSchema.parse(end.dateTime);
-      if (attendees) {
-        emailArraySchema.parse(attendees);
-      }
-      if (!recurrence || recurrence.length === 0) {
-        throw new Error('recurrence must contain at least one RRULE string');
-      }
-    } catch (error) {
-      return this.createValidationErrorResponse(error);
-    }
-
-    const finalCalendarId = calendarId || (await this.getPrimaryCalendarId());
-    logToFile(`Creating recurring event in calendar: ${finalCalendarId}`);
-
-    try {
-      const event: calendar_v3.Schema$Event = {
-        summary,
-        description,
-        start,
-        end,
-        attendees: attendees?.map((email) => ({ email })),
-        recurrence,
-      };
-
-      if (reminders) {
-        event.reminders = {
-          useDefault: reminders.useDefault,
-          overrides: reminders.overrides,
-        };
-      }
-
-      const calendar = await this.getCalendar();
-      const res = await calendar.events.insert({
-        calendarId: finalCalendarId,
-        requestBody: event,
-      });
-
-      logToFile(`Successfully created recurring event: ${res.data.id}`);
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(res.data),
-          },
-        ],
-      };
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      logToFile(`Error during calendar.createRecurringEvent: ${errorMessage}`);
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({ error: errorMessage }),
-          },
-        ],
-      };
-    }
-  };
-
-  createCalendar = async (input: CreateCalendarInput) => {
-    const { summary, description, timeZone } = input;
-    logToFile(`Creating calendar with summary: ${summary}`);
-
-    try {
-      const calendar = await this.getCalendar();
-      const res = await calendar.calendars.insert({
-        requestBody: {
-          summary,
-          description,
-          timeZone,
-        },
-      });
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(res.data),
-          },
-        ],
-      };
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      logToFile(`Error during calendar.createCalendar: ${errorMessage}`);
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({ error: errorMessage }),
-          },
-        ],
-      };
-    }
-  };
-
-  setEventReminders = async (input: SetEventRemindersInput) => {
-    const { eventId, calendarId, useDefault = true, overrides } = input;
-
-    const finalCalendarId = calendarId || (await this.getPrimaryCalendarId());
-    logToFile(`Setting reminders for event ${eventId} in ${finalCalendarId}`);
-
-    try {
-      const calendar = await this.getCalendar();
-      const res = await calendar.events.patch({
-        calendarId: finalCalendarId,
-        eventId,
-        requestBody: {
-          reminders: {
-            useDefault,
-            overrides,
-          },
-        },
-      });
-
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify(res.data),
-          },
-        ],
-      };
-    } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
-      logToFile(`Error during calendar.setEventReminders: ${errorMessage}`);
-      return {
-        content: [
-          {
-            type: 'text' as const,
-            text: JSON.stringify({ error: errorMessage }),
-          },
-        ],
-      };
-    }
-  };
 
   private async getCalendar(): Promise<calendar_v3.Calendar> {
     logToFile('Getting authenticated client for calendar...');
@@ -346,7 +233,17 @@ export class CalendarService {
   };
 
   createEvent = async (input: CreateEventInput) => {
-    const { calendarId, summary, description, start, end, attendees } = input;
+    const {
+      calendarId,
+      summary,
+      description,
+      start,
+      end,
+      attendees,
+      sendUpdates,
+      addGoogleMeet,
+      attachments,
+    } = input;
 
     // Validate datetime formats
     try {
@@ -366,19 +263,42 @@ export class CalendarService {
     logToFile(`Event start: ${start.dateTime}`);
     logToFile(`Event end: ${end.dateTime}`);
     logToFile(`Event attendees: ${attendees?.join(', ')}`);
+    if (addGoogleMeet) logToFile('Adding Google Meet link');
+    if (attachments?.length)
+      logToFile(`Attachments: ${attachments.length} file(s)`);
+
+    // Determine sendUpdates value
+    let finalSendUpdates = sendUpdates;
+    if (finalSendUpdates === undefined) {
+      finalSendUpdates = attendees?.length ? 'all' : 'none';
+    }
+    if (finalSendUpdates) {
+      logToFile(`Sending updates: ${finalSendUpdates}`);
+    }
+
     try {
-      const event = {
+      const event: calendar_v3.Schema$Event = {
         summary,
         description,
         start,
         end,
         attendees: attendees?.map((email) => ({ email })),
       };
+
       const calendar = await this.getCalendar();
-      const res = await calendar.events.insert({
+      const insertParams: calendar_v3.Params$Resource$Events$Insert = {
         calendarId: finalCalendarId,
         requestBody: event,
-      });
+        sendUpdates: finalSendUpdates,
+      };
+      this.applyMeetAndAttachments(
+        event,
+        insertParams,
+        addGoogleMeet,
+        attachments,
+      );
+
+      const res = await calendar.events.insert(insertParams);
       logToFile(`Successfully created event: ${res.data.id}`);
       return {
         content: [
@@ -400,6 +320,63 @@ export class CalendarService {
           },
         ],
       };
+    }
+  };
+
+  createCalendar = async (input: CreateCalendarInput) => {
+    const { summary, description, timeZone } = input;
+    logToFile(`Creating calendar with summary: ${summary}`);
+    try {
+      const calendar = await this.getCalendar();
+      const res = await calendar.calendars.insert({
+        requestBody: { summary, description, timeZone },
+      });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(res.data) }] };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logToFile(`Error during calendar.createCalendar: ${errorMessage}`);
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ error: errorMessage }) }] };
+    }
+  };
+
+  createRecurringEvent = async (input: CreateRecurringEventInput) => {
+    const { calendarId, summary, description, start, end, attendees, recurrence, reminders } = input;
+    try {
+      iso8601DateTimeSchema.parse(start.dateTime);
+      iso8601DateTimeSchema.parse(end.dateTime);
+      if (attendees) emailArraySchema.parse(attendees);
+      if (!recurrence || recurrence.length === 0) throw new Error('recurrence must contain at least one RRULE string');
+    } catch (error) {
+      return this.createValidationErrorResponse(error);
+    }
+    const finalCalendarId = calendarId || (await this.getPrimaryCalendarId());
+    logToFile(`Creating recurring event in calendar: ${finalCalendarId}`);
+    try {
+      const event: calendar_v3.Schema$Event = { summary, description, start, end, attendees: attendees?.map((email) => ({ email })), recurrence };
+      if (reminders) event.reminders = { useDefault: reminders.useDefault, overrides: reminders.overrides };
+      const calendar = await this.getCalendar();
+      const res = await calendar.events.insert({ calendarId: finalCalendarId, requestBody: event });
+      logToFile(`Successfully created recurring event: ${res.data.id}`);
+      return { content: [{ type: 'text' as const, text: JSON.stringify(res.data) }] };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logToFile(`Error during calendar.createRecurringEvent: ${errorMessage}`);
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ error: errorMessage }) }] };
+    }
+  };
+
+  setEventReminders = async (input: SetEventRemindersInput) => {
+    const { eventId, calendarId, useDefault = true, overrides } = input;
+    const finalCalendarId = calendarId || (await this.getPrimaryCalendarId());
+    logToFile(`Setting reminders for event ${eventId} in ${finalCalendarId}`);
+    try {
+      const calendar = await this.getCalendar();
+      const res = await calendar.events.patch({ calendarId: finalCalendarId, eventId, requestBody: { reminders: { useDefault, overrides } } });
+      return { content: [{ type: 'text' as const, text: JSON.stringify(res.data) }] };
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      logToFile(`Error during calendar.setEventReminders: ${errorMessage}`);
+      return { content: [{ type: 'text' as const, text: JSON.stringify({ error: errorMessage }) }] };
     }
   };
 
@@ -547,8 +524,17 @@ export class CalendarService {
   };
 
   updateEvent = async (input: UpdateEventInput) => {
-    const { eventId, calendarId, summary, description, start, end, attendees } =
-      input;
+    const {
+      eventId,
+      calendarId,
+      summary,
+      description,
+      start,
+      end,
+      attendees,
+      addGoogleMeet,
+      attachments,
+    } = input;
 
     // Validate datetime formats if provided
     try {
@@ -567,6 +553,9 @@ export class CalendarService {
 
     const finalCalendarId = calendarId || (await this.getPrimaryCalendarId());
     logToFile(`Updating event ${eventId} in calendar: ${finalCalendarId}`);
+    if (addGoogleMeet) logToFile('Adding Google Meet link');
+    if (attachments?.length)
+      logToFile(`Attachments: ${attachments.length} file(s)`);
 
     try {
       const calendar = await this.getCalendar();
@@ -580,11 +569,19 @@ export class CalendarService {
       if (attendees)
         requestBody.attendees = attendees.map((email) => ({ email }));
 
-      const res = await calendar.events.update({
+      const updateParams: calendar_v3.Params$Resource$Events$Update = {
         calendarId: finalCalendarId,
         eventId,
         requestBody,
-      });
+      };
+      this.applyMeetAndAttachments(
+        requestBody,
+        updateParams,
+        addGoogleMeet,
+        attachments,
+      );
+
+      const res = await calendar.events.update(updateParams);
 
       logToFile(`Successfully updated event: ${res.data.id}`);
       return {

--- a/workspace-server/src/services/CalendarService.ts
+++ b/workspace-server/src/services/CalendarService.ts
@@ -58,6 +58,7 @@ export interface UpdateEventInput {
   start?: { dateTime: string };
   end?: { dateTime: string };
   attendees?: string[];
+  sendUpdates?: 'all' | 'externalOnly' | 'none';
   addGoogleMeet?: boolean;
   attachments?: EventAttachment[];
 }
@@ -85,6 +86,7 @@ export interface CreateRecurringEventInput {
   end: { dateTime: string };
   attendees?: string[];
   recurrence: string[];
+  sendUpdates?: 'all' | 'externalOnly' | 'none';
   reminders?: {
     useDefault?: boolean;
     overrides?: Array<{ method: 'email' | 'popup'; minutes: number }>;
@@ -340,7 +342,7 @@ export class CalendarService {
   };
 
   createRecurringEvent = async (input: CreateRecurringEventInput) => {
-    const { calendarId, summary, description, start, end, attendees, recurrence, reminders } = input;
+    const { calendarId, summary, description, start, end, attendees, recurrence, sendUpdates, reminders } = input;
     try {
       iso8601DateTimeSchema.parse(start.dateTime);
       iso8601DateTimeSchema.parse(end.dateTime);
@@ -351,11 +353,21 @@ export class CalendarService {
     }
     const finalCalendarId = calendarId || (await this.getPrimaryCalendarId());
     logToFile(`Creating recurring event in calendar: ${finalCalendarId}`);
+
+    // Determine sendUpdates value
+    let finalSendUpdates = sendUpdates;
+    if (finalSendUpdates === undefined) {
+      finalSendUpdates = attendees?.length ? 'all' : 'none';
+    }
+    if (finalSendUpdates) {
+      logToFile(`Sending updates: ${finalSendUpdates}`);
+    }
+
     try {
       const event: calendar_v3.Schema$Event = { summary, description, start, end, attendees: attendees?.map((email) => ({ email })), recurrence };
       if (reminders) event.reminders = { useDefault: reminders.useDefault, overrides: reminders.overrides };
       const calendar = await this.getCalendar();
-      const res = await calendar.events.insert({ calendarId: finalCalendarId, requestBody: event });
+      const res = await calendar.events.insert({ calendarId: finalCalendarId, requestBody: event, sendUpdates: finalSendUpdates });
       logToFile(`Successfully created recurring event: ${res.data.id}`);
       return { content: [{ type: 'text' as const, text: JSON.stringify(res.data) }] };
     } catch (error) {
@@ -532,6 +544,7 @@ export class CalendarService {
       start,
       end,
       attendees,
+      sendUpdates,
       addGoogleMeet,
       attachments,
     } = input;
@@ -557,6 +570,15 @@ export class CalendarService {
     if (attachments?.length)
       logToFile(`Attachments: ${attachments.length} file(s)`);
 
+    // Determine sendUpdates value
+    let finalSendUpdates = sendUpdates;
+    if (finalSendUpdates === undefined) {
+      finalSendUpdates = attendees?.length ? 'all' : 'none';
+    }
+    if (finalSendUpdates) {
+      logToFile(`Sending updates: ${finalSendUpdates}`);
+    }
+
     try {
       const calendar = await this.getCalendar();
 
@@ -573,6 +595,7 @@ export class CalendarService {
         calendarId: finalCalendarId,
         eventId,
         requestBody,
+        sendUpdates: finalSendUpdates,
       };
       this.applyMeetAndAttachments(
         requestBody,

--- a/workspace-server/src/services/CalendarService.ts
+++ b/workspace-server/src/services/CalendarService.ts
@@ -142,9 +142,17 @@ export class CalendarService {
     }
   }
 
+  /**
+   * Standardized error message extraction helper.
+   * Converts any error to a string message safely.
+   */
+  private getErrorMessage(error: unknown): string {
+    return error instanceof Error ? error.message : String(error);
+  }
+
   private createValidationErrorResponse(error: unknown) {
     const errorMessage =
-      error instanceof Error ? error.message : 'Validation failed';
+      error instanceof Error ? this.getErrorMessage(error) : 'Validation failed';
     let helpMessage =
       'Please use strict ISO 8601 format with seconds and timezone. Examples: 2024-01-15T10:30:00Z (UTC) or 2024-01-15T10:30:00-05:00 (EST)';
 
@@ -220,8 +228,7 @@ export class CalendarService {
         ],
       };
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = this.getErrorMessage(error);
       logToFile(`Error during calendar.list: ${errorMessage}`);
       return {
         content: [
@@ -311,8 +318,7 @@ export class CalendarService {
         ],
       };
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = this.getErrorMessage(error);
       logToFile(`Error during calendar.createEvent: ${errorMessage}`);
       return {
         content: [
@@ -335,7 +341,7 @@ export class CalendarService {
       });
       return { content: [{ type: 'text' as const, text: JSON.stringify(res.data) }] };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = this.getErrorMessage(error);
       logToFile(`Error during calendar.createCalendar: ${errorMessage}`);
       return { content: [{ type: 'text' as const, text: JSON.stringify({ error: errorMessage }) }] };
     }
@@ -371,7 +377,7 @@ export class CalendarService {
       logToFile(`Successfully created recurring event: ${res.data.id}`);
       return { content: [{ type: 'text' as const, text: JSON.stringify(res.data) }] };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = this.getErrorMessage(error);
       logToFile(`Error during calendar.createRecurringEvent: ${errorMessage}`);
       return { content: [{ type: 'text' as const, text: JSON.stringify({ error: errorMessage }) }] };
     }
@@ -386,7 +392,7 @@ export class CalendarService {
       const res = await calendar.events.patch({ calendarId: finalCalendarId, eventId, requestBody: { reminders: { useDefault, overrides } } });
       return { content: [{ type: 'text' as const, text: JSON.stringify(res.data) }] };
     } catch (error) {
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage = this.getErrorMessage(error);
       logToFile(`Error during calendar.setEventReminders: ${errorMessage}`);
       return { content: [{ type: 'text' as const, text: JSON.stringify({ error: errorMessage }) }] };
     }
@@ -447,8 +453,7 @@ export class CalendarService {
         ],
       };
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = this.getErrorMessage(error);
       logToFile(`Error during calendar.listEvents: ${errorMessage}`);
       return {
         content: [
@@ -483,7 +488,7 @@ export class CalendarService {
     } catch (error) {
       const errorMessage =
         (error as any).response?.data?.error?.message ||
-        (error instanceof Error ? error.message : String(error));
+        this.getErrorMessage(error);
       logToFile(`Error during calendar.getEvent: ${errorMessage}`);
       return {
         content: [
@@ -522,7 +527,7 @@ export class CalendarService {
     } catch (error) {
       const errorMessage =
         (error as any).response?.data?.error?.message ||
-        (error instanceof Error ? error.message : String(error));
+        this.getErrorMessage(error);
       logToFile(`Error during calendar.deleteEvent: ${errorMessage}`);
       return {
         content: [
@@ -616,8 +621,7 @@ export class CalendarService {
         ],
       };
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = this.getErrorMessage(error);
       logToFile(`Error during calendar.updateEvent: ${errorMessage}`);
       return {
         content: [
@@ -718,8 +722,7 @@ export class CalendarService {
         ],
       };
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = this.getErrorMessage(error);
       logToFile(`Error during calendar.respondToEvent: ${errorMessage}`);
       return {
         content: [
@@ -910,8 +913,7 @@ export class CalendarService {
         ],
       };
     } catch (error) {
-      const errorMessage =
-        error instanceof Error ? error.message : String(error);
+      const errorMessage = this.getErrorMessage(error);
       logToFile(`Error during calendar.findFreeTime: ${errorMessage}`);
       return {
         content: [


### PR DESCRIPTION
## Summary
Adds three new Google Calendar tools for advanced calendar management.

## New Tools

### `calendar.createCalendar`
Creates a new calendar.
- **Parameters**: `summary`, `description` (optional), `timeZone` (optional)

### `calendar.createRecurringEvent`
Creates a recurring event in a calendar with RRULE support.
- **Parameters**: `calendarId` (optional), `summary`, `description` (optional), `start`, `end`, `attendees` (optional), `recurrence`, `reminders` (optional)

### `calendar.setEventReminders`
Sets custom reminders for an existing calendar event or resets to default reminders.
- **Parameters**: `eventId`, `calendarId` (optional), `useDefault` (optional), `overrides` (optional)

## Changes
- Added `createCalendar`, `createRecurringEvent`, `setEventReminders` methods to `CalendarService.ts`
- Added corresponding interfaces for input types
- Registered all three new tools in `index.ts`

## Testing
Tested locally with Google Calendar.