### PR TITLE
feat: feature configuration service for scope-based toggles

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: 'Home', link: '/' },
+      { text: 'Configuration', link: '/feature-configuration' },
       { text: 'Development', link: '/development' },
       { text: 'Release', link: '/release' },
       { text: 'Release Notes', link: '/release_notes' },
@@ -19,6 +20,7 @@ export default defineConfig({
         text: 'Documentation',
         items: [
           { text: 'Overview', link: '/' },
+          { text: 'Feature Configuration', link: '/feature-configuration' },
           { text: 'Development Guide', link: '/development' },
           { text: 'GCP Setup Guide', link: '/GCP-RECREATION' },
           { text: 'Release Guide', link: '/release' },

--- a/docs/development.md
+++ b/docs/development.md
@@ -156,6 +156,8 @@ used to maintain dot notation and avoid breaking existing configurations.
     - `__tests__/`: Contains all the tests.
     - `auth/`: Handles authentication.
     - `cli/`: CLI tools (e.g., headless OAuth login).
+    - `features/`: Feature configuration registry and resolver. See the
+      [Feature Configuration](../feature-configuration) docs.
     - `services/`: Contains the business logic for each service.
     - `utils/`: Contains utility functions.
   - `config/`: Contains configuration files.

--- a/docs/feature-configuration.md
+++ b/docs/feature-configuration.md
@@ -1,0 +1,204 @@
+# Feature Configuration
+
+The extension provides a feature configuration system that lets you control which
+services and scopes are enabled. Each Google Workspace service is split into
+**read** and **write** feature groups, giving you granular control over what the
+extension can access.
+
+## Feature Groups
+
+| Service    | Group | Scopes                                                    | Default |
+| ---------- | ----- | --------------------------------------------------------- | ------- |
+| `docs`     | read  | `documents`                                               | ON      |
+| `docs`     | write | `documents`, `drive`                                      | ON      |
+| `drive`    | read  | `drive.readonly`                                          | ON      |
+| `drive`    | write | `drive`                                                   | ON      |
+| `calendar` | read  | `calendar.readonly`                                       | ON      |
+| `calendar` | write | `calendar`                                                | ON      |
+| `chat`     | read  | `chat.spaces.readonly`, `chat.messages.readonly`, `chat.memberships.readonly` | ON |
+| `chat`     | write | `chat.spaces`, `chat.messages`, `chat.memberships`        | ON      |
+| `gmail`    | read  | `gmail.readonly`                                          | ON      |
+| `gmail`    | write | `gmail.modify`                                            | ON      |
+| `people`   | read  | `userinfo.profile`, `directory.readonly`                  | ON      |
+| `slides`   | read  | `presentations.readonly`                                  | ON      |
+| `slides`   | write | `presentations`                                           | **OFF** |
+| `sheets`   | read  | `spreadsheets.readonly`                                   | ON      |
+| `sheets`   | write | `spreadsheets`                                            | **OFF** |
+| `time`     | read  | _(none)_                                                  | ON      |
+| `tasks`    | read  | `tasks.readonly`                                          | **OFF** |
+| `tasks`    | write | `tasks`                                                   | **OFF** |
+
+**Read** groups contain tools with no side effects (search, get, list). **Write**
+groups contain tools that perform mutations (create, update, delete, send).
+
+Services whose write scopes aren't in the published GCP project (Slides write,
+Sheets write, Tasks) default to **OFF**. These can be enabled by contributors
+using their own GCP projects.
+
+## Configuration via `WORKSPACE_FEATURE_OVERRIDES`
+
+Use the `WORKSPACE_FEATURE_OVERRIDES` environment variable to enable or disable
+feature groups and individual tools.
+
+### Syntax
+
+```
+WORKSPACE_FEATURE_OVERRIDES="key:on|off,key:on|off,..."
+```
+
+Each entry is a comma-separated `key:value` pair where:
+- `key` is a feature group (e.g., `gmail.write`) or a tool name (e.g.,
+  `calendar.deleteEvent`)
+- `value` is `on` or `off`
+
+### Group-Level Overrides
+
+Disable or enable entire feature groups:
+
+```bash
+# Disable Gmail write tools (send, createDraft, modify, etc.)
+export WORKSPACE_FEATURE_OVERRIDES="gmail.write:off"
+
+# Disable all of Chat
+export WORKSPACE_FEATURE_OVERRIDES="chat.read:off,chat.write:off"
+
+# Enable experimental features (Slides write, Tasks)
+export WORKSPACE_FEATURE_OVERRIDES="slides.write:on,tasks.read:on,tasks.write:on"
+```
+
+### Tool-Level Overrides
+
+Disable specific tools within an enabled group (subtractive only):
+
+```bash
+# Keep calendar.write enabled but disable delete
+export WORKSPACE_FEATURE_OVERRIDES="calendar.deleteEvent:off"
+
+# Disable destructive Gmail tools while keeping modify/label tools
+export WORKSPACE_FEATURE_OVERRIDES="gmail.send:off,gmail.sendDraft:off"
+
+# Combine group and tool overrides
+export WORKSPACE_FEATURE_OVERRIDES="gmail.write:off,calendar.deleteEvent:off,slides.write:on"
+```
+
+::: warning
+Tool-level overrides are **subtractive only**. You cannot use `tool:on` to
+enable a tool whose feature group is disabled. To enable tools, enable their
+parent feature group.
+:::
+
+### Precedence
+
+The configuration follows a three-layer precedence model:
+
+1. **Baked-in defaults** — Current services default ON; experimental services
+   default OFF
+2. **Settings** — Future: overrides from the install-time settings UI
+3. **`WORKSPACE_FEATURE_OVERRIDES`** — Highest precedence; overrides everything
+
+### Effects
+
+When a feature group is disabled:
+- Its **tools are not registered** with the MCP server (clients won't see them)
+- Its **OAuth scopes are not requested** during authentication
+- If you re-enable a previously disabled feature, you may need to re-authenticate
+  to grant the new scopes
+
+## Tools by Feature Group
+
+### `docs.read`
+- `docs.getSuggestions`
+- `docs.getText`
+
+### `docs.write`
+- `docs.create`
+- `docs.writeText`
+- `docs.replaceText`
+- `docs.formatText`
+
+### `drive.read`
+- `drive.getComments`
+- `drive.findFolder`
+- `drive.search`
+- `drive.downloadFile`
+
+### `drive.write`
+- `drive.createFolder`
+- `drive.moveFile`
+- `drive.trashFile`
+- `drive.renameFile`
+
+### `calendar.read`
+- `calendar.list`
+- `calendar.listEvents`
+- `calendar.getEvent`
+- `calendar.findFreeTime`
+
+### `calendar.write`
+- `calendar.createEvent`
+- `calendar.updateEvent`
+- `calendar.respondToEvent`
+- `calendar.deleteEvent`
+
+### `chat.read`
+- `chat.listSpaces`
+- `chat.findSpaceByName`
+- `chat.getMessages`
+- `chat.findDmByEmail`
+- `chat.listThreads`
+
+### `chat.write`
+- `chat.sendMessage`
+- `chat.sendDm`
+- `chat.setUpSpace`
+
+### `gmail.read`
+- `gmail.search`
+- `gmail.get`
+- `gmail.downloadAttachment`
+- `gmail.listLabels`
+
+### `gmail.write`
+- `gmail.modify`
+- `gmail.batchModify`
+- `gmail.modifyThread`
+- `gmail.send`
+- `gmail.createDraft`
+- `gmail.sendDraft`
+- `gmail.createLabel`
+
+### `people.read`
+- `people.getUserProfile`
+- `people.getMe`
+- `people.getUserRelations`
+
+### `slides.read`
+- `slides.getText`
+- `slides.getMetadata`
+- `slides.getImages`
+- `slides.getSlideThumbnail`
+
+### `sheets.read`
+- `sheets.getText`
+- `sheets.getRange`
+- `sheets.getMetadata`
+
+### `time.read`
+- `time.getCurrentDate`
+- `time.getCurrentTime`
+- `time.getTimeZone`
+
+## For Contributors
+
+When adding a new service or tools:
+
+1. Define read and write feature group entries in
+   `workspace-server/src/features/feature-config.ts`
+2. Set the default state — **ON** for scopes in the published GCP project,
+   **OFF** otherwise
+3. Register your tools in `index.ts` as usual — the feature config wrapper
+   automatically skips disabled tools
+
+This lets contributors develop and merge new features without being blocked by
+the published GCP project's scope configuration. Contributors can test with
+their own GCP projects by enabling the feature via `WORKSPACE_FEATURE_OVERRIDES`.

--- a/workspace-server/src/__tests__/features/feature-config.test.ts
+++ b/workspace-server/src/__tests__/features/feature-config.test.ts
@@ -1,0 +1,59 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect } from '@jest/globals';
+import {
+  FEATURE_GROUPS,
+  featureGroupKey,
+} from '../../features/feature-config';
+
+describe('feature-config', () => {
+  it('should have unique feature group keys', () => {
+    const keys = FEATURE_GROUPS.map(featureGroupKey);
+    expect(keys.length).toBe(new Set(keys).size);
+  });
+
+  it('should not have duplicate tool names across groups', () => {
+    const allTools: string[] = [];
+    for (const fg of FEATURE_GROUPS) {
+      allTools.push(...fg.tools);
+    }
+    expect(allTools.length).toBe(new Set(allTools).size);
+  });
+
+  it('should have slides.write, sheets.write, tasks.read, and tasks.write defaulted to OFF', () => {
+    const offByDefault = FEATURE_GROUPS.filter((fg) => !fg.defaultEnabled).map(
+      featureGroupKey,
+    );
+    expect(offByDefault).toContain('slides.write');
+    expect(offByDefault).toContain('sheets.write');
+    expect(offByDefault).toContain('tasks.read');
+    expect(offByDefault).toContain('tasks.write');
+  });
+
+  it('should have all default-ON services with at least one tool', () => {
+    const defaultOnWithNoTools = FEATURE_GROUPS.filter(
+      (fg) => fg.defaultEnabled && fg.tools.length === 0,
+    );
+    expect(defaultOnWithNoTools).toEqual([]);
+  });
+
+  it('should have valid scope URLs', () => {
+    for (const fg of FEATURE_GROUPS) {
+      for (const scope of fg.scopes) {
+        expect(scope).toMatch(/^https:\/\/www\.googleapis\.com\/auth\//);
+      }
+    }
+  });
+
+  it('should have time.read with no scopes', () => {
+    const timeRead = FEATURE_GROUPS.find(
+      (fg) => fg.service === 'time' && fg.group === 'read',
+    );
+    expect(timeRead).toBeDefined();
+    expect(timeRead!.scopes).toEqual([]);
+  });
+});

--- a/workspace-server/src/__tests__/features/feature-resolver.test.ts
+++ b/workspace-server/src/__tests__/features/feature-resolver.test.ts
@@ -1,0 +1,200 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, jest } from '@jest/globals';
+
+jest.mock('../../utils/logger', () => ({
+  logToFile: jest.fn(),
+}));
+
+import { resolveFeatures, parseOverrides } from '../../features/feature-resolver';
+import { FEATURE_GROUPS, featureGroupKey } from '../../features/feature-config';
+
+describe('parseOverrides', () => {
+  it('should parse valid overrides', () => {
+    const result = parseOverrides('gmail.write:off,slides.write:on');
+    expect(result).toEqual([
+      { key: 'gmail.write', enabled: false },
+      { key: 'slides.write', enabled: true },
+    ]);
+  });
+
+  it('should handle whitespace', () => {
+    const result = parseOverrides(' gmail.write : off , slides.write : on ');
+    expect(result).toEqual([
+      { key: 'gmail.write', enabled: false },
+      { key: 'slides.write', enabled: true },
+    ]);
+  });
+
+  it('should skip empty entries', () => {
+    const result = parseOverrides('gmail.write:off,,slides.write:on,');
+    expect(result).toHaveLength(2);
+  });
+
+  it('should skip malformed entries (no colon)', () => {
+    const result = parseOverrides('gmail.write:off,badentry,slides.write:on');
+    expect(result).toHaveLength(2);
+  });
+
+  it('should skip entries with invalid values', () => {
+    const result = parseOverrides('gmail.write:off,slides.write:maybe');
+    expect(result).toHaveLength(1);
+    expect(result[0]).toEqual({ key: 'gmail.write', enabled: false });
+  });
+
+  it('should handle empty string', () => {
+    expect(parseOverrides('')).toEqual([]);
+  });
+
+  it('should handle tool-level overrides', () => {
+    const result = parseOverrides('calendar.deleteEvent:off,gmail.send:off');
+    expect(result).toEqual([
+      { key: 'calendar.deleteEvent', enabled: false },
+      { key: 'gmail.send', enabled: false },
+    ]);
+  });
+});
+
+describe('resolveFeatures', () => {
+  it('should return all default-ON tools when no overrides', () => {
+    const { enabledTools } = resolveFeatures();
+
+    // All tools from default-ON groups should be present
+    for (const fg of FEATURE_GROUPS) {
+      if (fg.defaultEnabled) {
+        for (const tool of fg.tools) {
+          expect(enabledTools.has(tool)).toBe(true);
+        }
+      }
+    }
+
+    // No tools from default-OFF groups
+    for (const fg of FEATURE_GROUPS) {
+      if (!fg.defaultEnabled) {
+        for (const tool of fg.tools) {
+          expect(enabledTools.has(tool)).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('should compute scopes only for enabled groups', () => {
+    const { requiredScopes } = resolveFeatures();
+
+    // Default-OFF groups should not contribute scopes
+    const offGroups = FEATURE_GROUPS.filter((fg) => !fg.defaultEnabled);
+    for (const fg of offGroups) {
+      for (const scope of fg.scopes) {
+        // Only check if scope is absent when it's not also in an ON group
+        const inOnGroup = FEATURE_GROUPS.some(
+          (other) =>
+            other.defaultEnabled && other.scopes.includes(scope),
+        );
+        if (!inOnGroup) {
+          expect(requiredScopes).not.toContain(scope);
+        }
+      }
+    }
+  });
+
+  it('should disable a group via env override', () => {
+    const { enabledTools, requiredScopes } = resolveFeatures(
+      undefined,
+      'gmail.write:off',
+    );
+
+    // Gmail write tools should be absent
+    expect(enabledTools.has('gmail.send')).toBe(false);
+    expect(enabledTools.has('gmail.createDraft')).toBe(false);
+    expect(enabledTools.has('gmail.modify')).toBe(false);
+
+    // Gmail read tools should still be present
+    expect(enabledTools.has('gmail.search')).toBe(true);
+    expect(enabledTools.has('gmail.get')).toBe(true);
+
+    // gmail.readonly scope should be present (from gmail.read)
+    expect(requiredScopes).toContain(
+      'https://www.googleapis.com/auth/gmail.readonly',
+    );
+  });
+
+  it('should enable a default-OFF group via env override', () => {
+    const { enabledTools, requiredScopes } = resolveFeatures(
+      undefined,
+      'tasks.read:on',
+    );
+
+    // tasks.read scopes should be present
+    expect(requiredScopes).toContain(
+      'https://www.googleapis.com/auth/tasks.readonly',
+    );
+  });
+
+  it('should disable individual tools via tool-level override', () => {
+    const { enabledTools } = resolveFeatures(
+      undefined,
+      'calendar.deleteEvent:off',
+    );
+
+    // calendar.deleteEvent should be disabled
+    expect(enabledTools.has('calendar.deleteEvent')).toBe(false);
+
+    // Other calendar write tools should still be present
+    expect(enabledTools.has('calendar.createEvent')).toBe(true);
+    expect(enabledTools.has('calendar.updateEvent')).toBe(true);
+  });
+
+  it('should ignore tool-level :on overrides (subtractive only)', () => {
+    // Disable gmail.write group, then try to re-enable gmail.send
+    const { enabledTools } = resolveFeatures(
+      undefined,
+      'gmail.write:off,gmail.send:on',
+    );
+
+    // gmail.send should still be disabled because its group is off
+    // and tool-level :on is ignored
+    expect(enabledTools.has('gmail.send')).toBe(false);
+  });
+
+  it('should apply settings overrides (layer 2)', () => {
+    const { enabledTools } = resolveFeatures(
+      { 'gmail.write': false },
+      undefined,
+    );
+
+    expect(enabledTools.has('gmail.send')).toBe(false);
+    expect(enabledTools.has('gmail.search')).toBe(true);
+  });
+
+  it('should give env overrides precedence over settings', () => {
+    // Settings disables gmail.write, but env re-enables it
+    const { enabledTools } = resolveFeatures(
+      { 'gmail.write': false },
+      'gmail.write:on',
+    );
+
+    expect(enabledTools.has('gmail.send')).toBe(true);
+  });
+
+  it('should combine group and tool-level overrides', () => {
+    const { enabledTools } = resolveFeatures(
+      undefined,
+      'calendar.deleteEvent:off,gmail.send:off',
+    );
+
+    expect(enabledTools.has('calendar.deleteEvent')).toBe(false);
+    expect(enabledTools.has('calendar.createEvent')).toBe(true);
+    expect(enabledTools.has('gmail.send')).toBe(false);
+    expect(enabledTools.has('gmail.createDraft')).toBe(true);
+  });
+
+  it('should deduplicate scopes', () => {
+    const { requiredScopes } = resolveFeatures();
+    const unique = new Set(requiredScopes);
+    expect(requiredScopes.length).toBe(unique.size);
+  });
+});

--- a/workspace-server/src/auth/scopes.ts
+++ b/workspace-server/src/auth/scopes.ts
@@ -4,20 +4,17 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { resolveFeatures } from '../features/index';
+
 /**
  * OAuth scopes required by the Google Workspace MCP server.
+ *
+ * Dynamically computed from the feature configuration registry,
+ * respecting WORKSPACE_FEATURE_OVERRIDES and default states.
+ *
  * Shared between the MCP server and the headless login CLI.
  */
-export const SCOPES = [
-  'https://www.googleapis.com/auth/documents',
-  'https://www.googleapis.com/auth/drive',
-  'https://www.googleapis.com/auth/calendar',
-  'https://www.googleapis.com/auth/chat.spaces',
-  'https://www.googleapis.com/auth/chat.messages',
-  'https://www.googleapis.com/auth/chat.memberships',
-  'https://www.googleapis.com/auth/userinfo.profile',
-  'https://www.googleapis.com/auth/gmail.modify',
-  'https://www.googleapis.com/auth/directory.readonly',
-  'https://www.googleapis.com/auth/presentations.readonly',
-  'https://www.googleapis.com/auth/spreadsheets.readonly',
-];
+export const SCOPES: string[] = resolveFeatures(
+  undefined,
+  process.env['WORKSPACE_FEATURE_OVERRIDES'],
+).requiredScopes;

--- a/workspace-server/src/features/feature-config.ts
+++ b/workspace-server/src/features/feature-config.ts
@@ -1,0 +1,245 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Feature Configuration Registry
+ *
+ * Defines read/write feature groups for each Google Workspace service.
+ * Each group specifies:
+ * - The OAuth scopes it requires
+ * - The tools it contains
+ * - Whether it's enabled by default
+ *
+ * Services whose write scopes aren't in the published GCP project
+ * (slides.write, sheets.write, tasks) default to OFF.
+ */
+
+const SCOPE_PREFIX = 'https://www.googleapis.com/auth/';
+
+function scopes(...names: string[]): string[] {
+  return names.map((name) => `${SCOPE_PREFIX}${name}`);
+}
+
+export interface FeatureGroup {
+  /** Service name (e.g., 'docs', 'gmail') */
+  service: string;
+  /** Group type: read (no side effects) or write (mutations) */
+  group: 'read' | 'write';
+  /** OAuth scopes required by this feature group */
+  scopes: string[];
+  /** Tool names belonging to this feature group */
+  tools: string[];
+  /** Whether this feature group is enabled by default */
+  defaultEnabled: boolean;
+}
+
+/**
+ * Canonical feature group key, e.g. "docs.read", "gmail.write"
+ */
+export function featureGroupKey(fg: FeatureGroup): string {
+  return `${fg.service}.${fg.group}`;
+}
+
+export const FEATURE_GROUPS: FeatureGroup[] = [
+  // Docs
+  {
+    service: 'docs',
+    group: 'read',
+    scopes: scopes('documents'),
+    tools: ['docs.getSuggestions', 'docs.getText'],
+    defaultEnabled: true,
+  },
+  {
+    service: 'docs',
+    group: 'write',
+    scopes: scopes('documents', 'drive'),
+    tools: [
+      'docs.create',
+      'docs.writeText',
+      'docs.replaceText',
+      'docs.formatText',
+    ],
+    defaultEnabled: true,
+  },
+
+  // Drive
+  {
+    service: 'drive',
+    group: 'read',
+    scopes: scopes('drive.readonly'),
+    tools: [
+      'drive.getComments',
+      'drive.findFolder',
+      'drive.search',
+      'drive.downloadFile',
+    ],
+    defaultEnabled: true,
+  },
+  {
+    service: 'drive',
+    group: 'write',
+    scopes: scopes('drive'),
+    tools: [
+      'drive.createFolder',
+      'drive.moveFile',
+      'drive.trashFile',
+      'drive.renameFile',
+    ],
+    defaultEnabled: true,
+  },
+
+  // Calendar
+  {
+    service: 'calendar',
+    group: 'read',
+    scopes: scopes('calendar.readonly'),
+    tools: [
+      'calendar.list',
+      'calendar.listEvents',
+      'calendar.getEvent',
+      'calendar.findFreeTime',
+    ],
+    defaultEnabled: true,
+  },
+  {
+    service: 'calendar',
+    group: 'write',
+    scopes: scopes('calendar'),
+    tools: [
+      'calendar.createEvent',
+      'calendar.updateEvent',
+      'calendar.respondToEvent',
+      'calendar.deleteEvent',
+    ],
+    defaultEnabled: true,
+  },
+
+  // Chat
+  {
+    service: 'chat',
+    group: 'read',
+    scopes: scopes(
+      'chat.spaces.readonly',
+      'chat.messages.readonly',
+      'chat.memberships.readonly',
+    ),
+    tools: [
+      'chat.listSpaces',
+      'chat.findSpaceByName',
+      'chat.getMessages',
+      'chat.findDmByEmail',
+      'chat.listThreads',
+    ],
+    defaultEnabled: true,
+  },
+  {
+    service: 'chat',
+    group: 'write',
+    scopes: scopes('chat.spaces', 'chat.messages', 'chat.memberships'),
+    tools: ['chat.sendMessage', 'chat.sendDm', 'chat.setUpSpace'],
+    defaultEnabled: true,
+  },
+
+  // Gmail
+  {
+    service: 'gmail',
+    group: 'read',
+    scopes: scopes('gmail.readonly'),
+    tools: [
+      'gmail.search',
+      'gmail.get',
+      'gmail.downloadAttachment',
+      'gmail.listLabels',
+    ],
+    defaultEnabled: true,
+  },
+  {
+    service: 'gmail',
+    group: 'write',
+    scopes: scopes('gmail.modify'),
+    tools: [
+      'gmail.modify',
+      'gmail.batchModify',
+      'gmail.modifyThread',
+      'gmail.send',
+      'gmail.createDraft',
+      'gmail.sendDraft',
+      'gmail.createLabel',
+    ],
+    defaultEnabled: true,
+  },
+
+  // People
+  {
+    service: 'people',
+    group: 'read',
+    scopes: scopes('userinfo.profile', 'directory.readonly'),
+    tools: ['people.getUserProfile', 'people.getMe', 'people.getUserRelations'],
+    defaultEnabled: true,
+  },
+
+  // Slides
+  {
+    service: 'slides',
+    group: 'read',
+    scopes: scopes('presentations.readonly'),
+    tools: [
+      'slides.getText',
+      'slides.getMetadata',
+      'slides.getImages',
+      'slides.getSlideThumbnail',
+    ],
+    defaultEnabled: true,
+  },
+  {
+    service: 'slides',
+    group: 'write',
+    scopes: scopes('presentations'),
+    tools: [],
+    defaultEnabled: false,
+  },
+
+  // Sheets
+  {
+    service: 'sheets',
+    group: 'read',
+    scopes: scopes('spreadsheets.readonly'),
+    tools: ['sheets.getText', 'sheets.getRange', 'sheets.getMetadata'],
+    defaultEnabled: true,
+  },
+  {
+    service: 'sheets',
+    group: 'write',
+    scopes: scopes('spreadsheets'),
+    tools: [],
+    defaultEnabled: false,
+  },
+
+  // Time (no scopes needed)
+  {
+    service: 'time',
+    group: 'read',
+    scopes: [],
+    tools: ['time.getCurrentDate', 'time.getCurrentTime', 'time.getTimeZone'],
+    defaultEnabled: true,
+  },
+
+  // Tasks (experimental — not in published GCP project)
+  {
+    service: 'tasks',
+    group: 'read',
+    scopes: scopes('tasks.readonly'),
+    tools: [],
+    defaultEnabled: false,
+  },
+  {
+    service: 'tasks',
+    group: 'write',
+    scopes: scopes('tasks'),
+    tools: [],
+    defaultEnabled: false,
+  },
+];

--- a/workspace-server/src/features/feature-resolver.ts
+++ b/workspace-server/src/features/feature-resolver.ts
@@ -1,0 +1,185 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Feature Resolver
+ *
+ * Resolves the final set of enabled tools and required OAuth scopes
+ * using a three-layer precedence model:
+ *
+ *   1. Baked-in defaults (from feature-config.ts)
+ *   2. Settings from gemini-extension.json (future — placeholder layer)
+ *   3. WORKSPACE_FEATURE_OVERRIDES env var (highest precedence)
+ *
+ * Override syntax examples:
+ *   - Group-level:  "gmail.write:off,slides.write:on"
+ *   - Tool-level:   "calendar.deleteEvent:off,gmail.send:off"
+ *
+ * Tool-level overrides are subtractive only — they can disable individual
+ * tools within an enabled group but cannot enable tools in a disabled group.
+ */
+
+import { logToFile } from '../utils/logger';
+import {
+  FEATURE_GROUPS,
+  featureGroupKey,
+  type FeatureGroup,
+} from './feature-config';
+
+export interface ResolvedFeatures {
+  /** Set of tool names that should be registered */
+  enabledTools: Set<string>;
+  /** Deduplicated list of OAuth scopes required by enabled features */
+  requiredScopes: string[];
+}
+
+interface Override {
+  key: string; // e.g. "gmail.write" or "calendar.deleteEvent"
+  enabled: boolean;
+}
+
+/**
+ * Parses the WORKSPACE_FEATURE_OVERRIDES env var.
+ *
+ * Format: comma-separated "key:on" or "key:off" pairs.
+ * Whitespace is trimmed. Empty entries are skipped.
+ */
+export function parseOverrides(raw: string): Override[] {
+  const overrides: Override[] = [];
+  for (const entry of raw.split(',')) {
+    const trimmed = entry.trim();
+    if (!trimmed) continue;
+
+    const colonIndex = trimmed.lastIndexOf(':');
+    if (colonIndex === -1) {
+      logToFile(
+        `[feature-resolver] Ignoring malformed override (missing ':'): "${trimmed}"`,
+      );
+      continue;
+    }
+
+    const key = trimmed.slice(0, colonIndex).trim();
+    const value = trimmed.slice(colonIndex + 1).trim().toLowerCase();
+
+    if (value !== 'on' && value !== 'off') {
+      logToFile(
+        `[feature-resolver] Ignoring override with invalid value (expected on/off): "${trimmed}"`,
+      );
+      continue;
+    }
+
+    overrides.push({ key, enabled: value === 'on' });
+  }
+  return overrides;
+}
+
+/**
+ * Build a lookup from feature group key ("docs.read") to FeatureGroup.
+ */
+function buildGroupIndex(): Map<string, FeatureGroup> {
+  const index = new Map<string, FeatureGroup>();
+  for (const fg of FEATURE_GROUPS) {
+    index.set(featureGroupKey(fg), fg);
+  }
+  return index;
+}
+
+/**
+ * Build a lookup from tool name to its feature group key.
+ */
+function buildToolIndex(): Map<string, string> {
+  const index = new Map<string, string>();
+  for (const fg of FEATURE_GROUPS) {
+    const key = featureGroupKey(fg);
+    for (const tool of fg.tools) {
+      index.set(tool, key);
+    }
+  }
+  return index;
+}
+
+/**
+ * Resolves which features are enabled and computes the required scopes.
+ *
+ * @param settingsOverrides - Future: overrides from gemini-extension.json settings UI
+ * @param envOverrides - Raw value of WORKSPACE_FEATURE_OVERRIDES env var
+ */
+export function resolveFeatures(
+  settingsOverrides?: Record<string, boolean>,
+  envOverrides?: string,
+): ResolvedFeatures {
+  const groupIndex = buildGroupIndex();
+  const toolIndex = buildToolIndex();
+
+  // Layer 1: Start with defaults
+  const groupEnabled = new Map<string, boolean>();
+  for (const fg of FEATURE_GROUPS) {
+    groupEnabled.set(featureGroupKey(fg), fg.defaultEnabled);
+  }
+
+  // Layer 2: Apply settings overrides (future — from gemini-extension.json)
+  if (settingsOverrides) {
+    for (const [key, enabled] of Object.entries(settingsOverrides)) {
+      if (groupIndex.has(key)) {
+        groupEnabled.set(key, enabled);
+      }
+    }
+  }
+
+  // Layer 3: Apply env var overrides (highest precedence)
+  const toolDisabled = new Set<string>();
+  if (envOverrides) {
+    const overrides = parseOverrides(envOverrides);
+    for (const { key, enabled } of overrides) {
+      if (groupIndex.has(key)) {
+        // Group-level override
+        groupEnabled.set(key, enabled);
+      } else if (toolIndex.has(key)) {
+        // Tool-level override (subtractive only)
+        if (!enabled) {
+          toolDisabled.add(key);
+        } else {
+          logToFile(
+            `[feature-resolver] Tool-level override "${key}:on" ignored — tool overrides are subtractive only`,
+          );
+        }
+      } else {
+        logToFile(
+          `[feature-resolver] Unknown override key: "${key}" — not a known feature group or tool`,
+        );
+      }
+    }
+  }
+
+  // Collect enabled tools and scopes
+  const enabledTools = new Set<string>();
+  const scopeSet = new Set<string>();
+
+  for (const fg of FEATURE_GROUPS) {
+    const key = featureGroupKey(fg);
+    if (!groupEnabled.get(key)) continue;
+
+    // Add scopes for this enabled group
+    for (const scope of fg.scopes) {
+      scopeSet.add(scope);
+    }
+
+    // Add tools (minus individually disabled ones)
+    for (const tool of fg.tools) {
+      if (!toolDisabled.has(tool)) {
+        enabledTools.add(tool);
+      }
+    }
+  }
+
+  const requiredScopes = [...scopeSet];
+
+  logToFile(
+    `[feature-resolver] Resolved ${enabledTools.size} tools, ${requiredScopes.length} scopes`,
+  );
+
+  return { enabledTools, requiredScopes };
+}

--- a/workspace-server/src/features/index.ts
+++ b/workspace-server/src/features/index.ts
@@ -1,0 +1,10 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+export { FEATURE_GROUPS, featureGroupKey } from './feature-config';
+export type { FeatureGroup } from './feature-config';
+export { resolveFeatures, parseOverrides } from './feature-resolver';
+export type { ResolvedFeatures } from './feature-resolver';

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -21,9 +21,10 @@ import { SlidesService } from './services/SlidesService';
 import { SheetsService } from './services/SheetsService';
 import { GMAIL_SEARCH_MAX_RESULTS } from './utils/constants';
 
-import { setLoggingEnabled } from './utils/logger';
+import { setLoggingEnabled, logToFile } from './utils/logger';
 import { applyToolNameNormalization } from './utils/tool-normalization';
 import { SCOPES } from './auth/scopes';
+import { resolveFeatures } from './features/index';
 
 // Shared schemas for calendar event tools
 const eventMeetAndAttachmentsSchema = {
@@ -100,6 +101,18 @@ async function main() {
     },
   };
 
+  // Resolve enabled features from defaults + env overrides
+  const { enabledTools } = resolveFeatures(
+    undefined,
+    process.env['WORKSPACE_FEATURE_OVERRIDES'],
+  );
+
+  logToFile(
+    `[features] ${enabledTools.size} tools enabled. Disabled: ${
+      process.env['WORKSPACE_FEATURE_OVERRIDES'] || '(none)'
+    }`,
+  );
+
   const authManager = new AuthManager(SCOPES);
 
   // 2. Create the server instance
@@ -135,7 +148,18 @@ async function main() {
   const separator = useDotNames ? '.' : '_';
   applyToolNameNormalization(server, useDotNames);
 
-  server.registerTool(
+  // Wrap registerTool to skip tools disabled by feature config.
+  // Auth tools are always registered (not gated by features).
+  const originalRegisterTool = server.registerTool.bind(server);
+  const registerTool: typeof server.registerTool = (name, config, handler) => {
+    if (!enabledTools.has(name) && !name.startsWith('auth.')) {
+      logToFile(`[features] Skipping disabled tool: ${name}`);
+      return;
+    }
+    return originalRegisterTool(name, config, handler);
+  };
+
+  registerTool(
     'auth.clear',
     {
       description:
@@ -155,7 +179,7 @@ async function main() {
     },
   );
 
-  server.registerTool(
+  registerTool(
     'auth.refreshToken',
     {
       description: 'Manually triggers the token refresh process.',
@@ -174,7 +198,7 @@ async function main() {
     },
   );
 
-  server.registerTool(
+  registerTool(
     'docs.getSuggestions',
     {
       description: 'Retrieves suggested edits from a Google Doc.',
@@ -187,7 +211,7 @@ async function main() {
     docsService.getSuggestions,
   );
 
-  server.registerTool(
+  registerTool(
     'drive.getComments',
     {
       description:
@@ -201,7 +225,7 @@ async function main() {
     driveService.getComments,
   );
 
-  server.registerTool(
+  registerTool(
     'docs.create',
     {
       description:
@@ -217,7 +241,7 @@ async function main() {
     docsService.create,
   );
 
-  server.registerTool(
+  registerTool(
     'docs.writeText',
     {
       description: 'Writes text to a Google Doc at a specified position.',
@@ -241,7 +265,7 @@ async function main() {
     docsService.writeText,
   );
 
-  server.registerTool(
+  registerTool(
     'drive.findFolder',
     {
       description: 'Finds a folder by name in Google Drive.',
@@ -253,7 +277,7 @@ async function main() {
     driveService.findFolder,
   );
 
-  server.registerTool(
+  registerTool(
     'drive.createFolder',
     {
       description: 'Creates a new folder in Google Drive.',
@@ -272,7 +296,7 @@ async function main() {
     driveService.createFolder,
   );
 
-  server.registerTool(
+  registerTool(
     'docs.getText',
     {
       description: 'Retrieves the text content of a Google Doc.',
@@ -290,7 +314,7 @@ async function main() {
     docsService.getText,
   );
 
-  server.registerTool(
+  registerTool(
     'docs.replaceText',
     {
       description:
@@ -312,7 +336,7 @@ async function main() {
     docsService.replaceText,
   );
 
-  server.registerTool(
+  registerTool(
     'docs.formatText',
     {
       description:
@@ -356,7 +380,7 @@ async function main() {
   );
 
   // Slides tools
-  server.registerTool(
+  registerTool(
     'slides.getText',
     {
       description:
@@ -371,7 +395,7 @@ async function main() {
     slidesService.getText,
   );
 
-  server.registerTool(
+  registerTool(
     'slides.getMetadata',
     {
       description: 'Gets metadata about a Google Slides presentation.',
@@ -385,7 +409,7 @@ async function main() {
     slidesService.getMetadata,
   );
 
-  server.registerTool(
+  registerTool(
     'slides.getImages',
     {
       description:
@@ -406,7 +430,7 @@ async function main() {
     slidesService.getImages,
   );
 
-  server.registerTool(
+  registerTool(
     'slides.getSlideThumbnail',
     {
       description:
@@ -431,7 +455,7 @@ async function main() {
   );
 
   // Sheets tools
-  server.registerTool(
+  registerTool(
     'sheets.getText',
     {
       description: 'Retrieves the content of a Google Sheets spreadsheet.',
@@ -449,7 +473,7 @@ async function main() {
     sheetsService.getText,
   );
 
-  server.registerTool(
+  registerTool(
     'sheets.getRange',
     {
       description:
@@ -465,7 +489,7 @@ async function main() {
     sheetsService.getRange,
   );
 
-  server.registerTool(
+  registerTool(
     'sheets.getMetadata',
     {
       description: 'Gets metadata about a Google Sheets spreadsheet.',
@@ -477,7 +501,7 @@ async function main() {
     sheetsService.getMetadata,
   );
 
-  server.registerTool(
+  registerTool(
     'drive.search',
     {
       description:
@@ -515,7 +539,7 @@ async function main() {
     driveService.search,
   );
 
-  server.registerTool(
+  registerTool(
     'drive.downloadFile',
     {
       description:
@@ -532,7 +556,7 @@ async function main() {
     driveService.downloadFile,
   );
 
-  server.registerTool(
+  registerTool(
     'drive.moveFile',
     {
       description:
@@ -556,7 +580,7 @@ async function main() {
     driveService.moveFile,
   );
 
-  server.registerTool(
+  registerTool(
     'drive.trashFile',
     {
       description:
@@ -568,7 +592,7 @@ async function main() {
     driveService.trashFile,
   );
 
-  server.registerTool(
+  registerTool(
     'drive.renameFile',
     {
       description: 'Renames a file or folder in Google Drive.',
@@ -584,7 +608,7 @@ async function main() {
     driveService.renameFile,
   );
 
-  server.registerTool(
+  registerTool(
     'calendar.list',
     {
       description: "Lists all of the user's calendars.",
@@ -594,7 +618,7 @@ async function main() {
     calendarService.listCalendars,
   );
 
-  server.registerTool(
+  registerTool(
     'calendar.createEvent',
     {
       description:
@@ -638,7 +662,7 @@ async function main() {
     calendarService.createEvent,
   );
 
-  server.registerTool(
+  registerTool(
     'calendar.listEvents',
     {
       description: 'Lists events from a calendar. Defaults to upcoming events.',
@@ -666,7 +690,7 @@ async function main() {
     calendarService.listEvents,
   );
 
-  server.registerTool(
+  registerTool(
     'calendar.getEvent',
     {
       description: 'Gets the details of a specific calendar event.',
@@ -684,7 +708,7 @@ async function main() {
     calendarService.getEvent,
   );
 
-  server.registerTool(
+  registerTool(
     'calendar.findFreeTime',
     {
       description: 'Finds a free time slot for multiple people to meet.',
@@ -711,7 +735,7 @@ async function main() {
     calendarService.findFreeTime,
   );
 
-  server.registerTool(
+  registerTool(
     'calendar.updateEvent',
     {
       description:
@@ -758,7 +782,7 @@ async function main() {
     calendarService.updateEvent,
   );
 
-  server.registerTool(
+  registerTool(
     'calendar.respondToEvent',
     {
       description:
@@ -787,7 +811,7 @@ async function main() {
     calendarService.respondToEvent,
   );
 
-  server.registerTool(
+  registerTool(
     'calendar.deleteEvent',
     {
       description: 'Deletes an event from a calendar.',
@@ -804,7 +828,7 @@ async function main() {
     calendarService.deleteEvent,
   );
 
-  server.registerTool(
+  registerTool(
     'chat.listSpaces',
     {
       description: 'Lists the spaces the user is a member of.',
@@ -814,7 +838,7 @@ async function main() {
     chatService.listSpaces,
   );
 
-  server.registerTool(
+  registerTool(
     'chat.findSpaceByName',
     {
       description: 'Finds a Google Chat space by its display name.',
@@ -828,7 +852,7 @@ async function main() {
     chatService.findSpaceByName,
   );
 
-  server.registerTool(
+  registerTool(
     'chat.sendMessage',
     {
       description: 'Sends a message to a Google Chat space.',
@@ -850,7 +874,7 @@ async function main() {
     chatService.sendMessage,
   );
 
-  server.registerTool(
+  registerTool(
     'chat.getMessages',
     {
       description: 'Gets messages from a Google Chat space.',
@@ -888,7 +912,7 @@ async function main() {
     chatService.getMessages,
   );
 
-  server.registerTool(
+  registerTool(
     'chat.sendDm',
     {
       description: 'Sends a direct message to a user.',
@@ -909,7 +933,7 @@ async function main() {
     chatService.sendDm,
   );
 
-  server.registerTool(
+  registerTool(
     'chat.findDmByEmail',
     {
       description: "Finds a Google Chat DM space by a user's email address.",
@@ -924,7 +948,7 @@ async function main() {
     chatService.findDmByEmail,
   );
 
-  server.registerTool(
+  registerTool(
     'chat.listThreads',
     {
       description:
@@ -949,7 +973,7 @@ async function main() {
     chatService.listThreads,
   );
 
-  server.registerTool(
+  registerTool(
     'chat.setUpSpace',
     {
       description:
@@ -967,7 +991,7 @@ async function main() {
   );
 
   // Gmail tools
-  server.registerTool(
+  registerTool(
     'gmail.search',
     {
       description: 'Search for emails in Gmail using query parameters.',
@@ -1002,7 +1026,7 @@ async function main() {
     gmailService.search,
   );
 
-  server.registerTool(
+  registerTool(
     'gmail.get',
     {
       description: 'Get the full content of a specific email message.',
@@ -1018,7 +1042,7 @@ async function main() {
     gmailService.get,
   );
 
-  server.registerTool(
+  registerTool(
     'gmail.downloadAttachment',
     {
       description:
@@ -1040,7 +1064,7 @@ async function main() {
     gmailService.downloadAttachment,
   );
 
-  server.registerTool(
+  registerTool(
     'gmail.modify',
     {
       description: `Modify a Gmail message. Supported modifications include:
@@ -1078,7 +1102,7 @@ There are a list of system labels that can be modified on a message:
     gmailService.modify,
   );
 
-  server.registerTool(
+  registerTool(
     'gmail.batchModify',
     {
       description: `Bulk modify up to 1,000 Gmail messages at once. Applies the same label changes to all specified messages in a single API call. This is much more efficient than modifying messages individually.
@@ -1118,7 +1142,7 @@ System labels that can be modified:
     gmailService.batchModify,
   );
 
-  server.registerTool(
+  registerTool(
     'gmail.modifyThread',
     {
       description: `Modify labels on all messages in a Gmail thread. This applies label changes to every message in the thread at once, which is useful for operations like marking an entire conversation as read.
@@ -1150,7 +1174,7 @@ System labels that can be modified:
     gmailService.modifyThread,
   );
 
-  server.registerTool(
+  registerTool(
     'gmail.send',
     {
       description: 'Send an email message.',
@@ -1159,7 +1183,7 @@ System labels that can be modified:
     gmailService.send,
   );
 
-  server.registerTool(
+  registerTool(
     'gmail.createDraft',
     {
       description: 'Create a draft email message.',
@@ -1176,7 +1200,7 @@ System labels that can be modified:
     gmailService.createDraft,
   );
 
-  server.registerTool(
+  registerTool(
     'gmail.sendDraft',
     {
       description: 'Send a previously created draft email.',
@@ -1187,7 +1211,7 @@ System labels that can be modified:
     gmailService.sendDraft,
   );
 
-  server.registerTool(
+  registerTool(
     'gmail.listLabels',
     {
       description: "List all Gmail labels in the user's mailbox.",
@@ -1197,7 +1221,7 @@ System labels that can be modified:
     gmailService.listLabels,
   );
 
-  server.registerTool(
+  registerTool(
     'gmail.createLabel',
     {
       description:
@@ -1222,7 +1246,7 @@ System labels that can be modified:
   );
 
   // Time tools
-  server.registerTool(
+  registerTool(
     'time.getCurrentDate',
     {
       description:
@@ -1233,7 +1257,7 @@ System labels that can be modified:
     timeService.getCurrentDate,
   );
 
-  server.registerTool(
+  registerTool(
     'time.getCurrentTime',
     {
       description:
@@ -1244,7 +1268,7 @@ System labels that can be modified:
     timeService.getCurrentTime,
   );
 
-  server.registerTool(
+  registerTool(
     'time.getTimeZone',
     {
       description:
@@ -1256,7 +1280,7 @@ System labels that can be modified:
   );
 
   // People tools
-  server.registerTool(
+  registerTool(
     'people.getUserProfile',
     {
       description: "Gets a user's profile information.",
@@ -1281,7 +1305,7 @@ System labels that can be modified:
     peopleService.getUserProfile,
   );
 
-  server.registerTool(
+  registerTool(
     'people.getMe',
     {
       description: 'Gets the profile information of the authenticated user.',
@@ -1291,7 +1315,7 @@ System labels that can be modified:
     peopleService.getMe,
   );
 
-  server.registerTool(
+  registerTool(
     'people.getUserRelations',
     {
       description:


### PR DESCRIPTION
## Summary

Implements the Feature Configuration Service  giving users and contributors control over which services and OAuth scopes the extension requests.

- **Feature registry** (`features/feature-config.ts`) — 18 read/write feature groups across all services, each declaring its scopes, tools, and default state
- **Feature resolver** (`features/feature-resolver.ts`) — Three-layer resolution: baked-in defaults → settings (future) → `WORKSPACE_FEATURE_OVERRIDES` env var
- **Dynamic scopes** — OAuth scopes are now computed from enabled features instead of hardcoded
- **Gated tool registration** — Disabled tools are silently skipped; auth tools always register
- **Documentation** — Full feature configuration guide added to VitePress docs site

### Configuration

```bash
# Disable Gmail writes and calendar delete
WORKSPACE_FEATURE_OVERRIDES="gmail.write:off,calendar.deleteEvent:off"

# Enable experimental features
WORKSPACE_FEATURE_OVERRIDES="slides.write:on,tasks.read:on,tasks.write:on"
```

Supports group-level (`gmail.write:off`) and tool-level (`calendar.deleteEvent:off`) overrides. Tool-level overrides are subtractive only.

### Default-OFF features
`slides.write`, `sheets.write`, `tasks.read`, `tasks.write` — scopes not in the published GCP project. Contributors can enable them with their own GCP projects.

## Test plan

- [x] 23 new unit tests covering registry integrity, override parsing, group enable/disable, tool-level overrides, subtractive-only enforcement, layer precedence, and scope deduplication
- [ ] Manual: verify `WORKSPACE_FEATURE_OVERRIDES="gmail.write:off"` hides Gmail write tools from MCP tool listing
- [ ] Manual: verify re-enabling a disabled feature prompts re-auth for new scopes
- [ ] Manual: verify no behavior change when env var is unset (backward compatible)

