### PR TITLE
feat: make MCP server agent-agnostic

### DIFF
--- a/.clinerules
+++ b/.clinerules
@@ -1,0 +1,46 @@
+# Google Workspace MCP Server
+
+This is a Google Workspace Extension providing MCP tools for Docs, Sheets,
+Slides, Gmail, Drive, Calendar, Chat, and People APIs via the Model Context
+Protocol (MCP).
+
+## Build & Test
+
+```bash
+npm install && npm run build   # install and build
+npm test                       # run all tests
+npx jest <path/to/test.ts>     # run a single test
+npm run lint && npm run lint:fix
+```
+
+## Development Conventions
+
+- Entry point: `workspace-server/src/index.ts` (registers all MCP tools)
+- Services: `workspace-server/src/services/` (one file per Google service)
+- Tests: `workspace-server/src/__tests__/services/` (mirrors services/)
+- Every `.ts` file needs the Apache 2.0 license header
+- Node.js imports must use the `node:` prefix (e.g., `node:fs`, `node:path`)
+- Unused vars/params must be prefixed with `_`
+- Service methods are arrow functions on class properties (not regular methods)
+
+## Adding a New Tool
+
+1. Add an arrow-function method to the relevant `services/*.ts` class
+2. Call `server.registerTool('namespace.action', { description, inputSchema }, handler)` in `index.ts`
+3. Use zod for `inputSchema` — see existing tools for patterns
+4. Add a test in `__tests__/services/`
+
+## MCP Resources Available (when server is running)
+
+When the MCP server is configured and running, load these resources for
+behavioral guidance before working with each service:
+
+- `workspace://context` — Core behavioral guide (load at session start)
+- `workspace://skills/gmail` — Gmail composition and search guide
+- `workspace://skills/google-docs` — Docs two-step format workflow
+- `workspace://skills/google-calendar` — Calendar timezone-first workflow
+- `workspace://skills/google-chat` — Chat message formatting guide
+- `workspace://skills/google-sheets` — Sheets query and range guide
+- `workspace://skills/google-slides` — Slides extraction guide
+
+See [AGENT-CONTEXT.md](AGENT-CONTEXT.md) for a full standalone behavioral guide.

--- a/.copilot/mcp-config.json
+++ b/.copilot/mcp-config.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "google-workspace": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["workspace-server/dist/index.js"]
+    }
+  }
+}

--- a/.cursor/rules/google-workspace.md
+++ b/.cursor/rules/google-workspace.md
@@ -1,0 +1,45 @@
+---
+description: Google Workspace MCP Server development and usage guide
+globs: ["workspace-server/src/**/*.ts", "skills/**/*.md", "commands/**/*.toml"]
+alwaysApply: true
+---
+
+# Google Workspace MCP Server
+
+This is a Google Workspace Extension providing MCP tools for Docs, Sheets,
+Slides, Gmail, Drive, Calendar, Chat, and People APIs.
+
+## Build & Test
+
+```bash
+npm install && npm run build   # install and build
+npm test                       # run all tests
+npx jest <path/to/test.ts>     # run a single test
+npm run lint && npm run lint:fix
+```
+
+## Development Conventions
+
+- Entry point: `workspace-server/src/index.ts` (registers all MCP tools)
+- Services: `workspace-server/src/services/` (one file per Google service)
+- Tests: `workspace-server/src/__tests__/services/` (mirrors services/)
+- Every `.ts` file needs the Apache 2.0 license header comment block
+- Node.js imports must use the `node:` prefix (e.g., `node:fs`, `node:path`)
+- Unused vars/params must be prefixed with `_`
+- Service methods are arrow functions on class properties (not regular methods)
+
+## Adding a New Tool
+
+1. Add an arrow-function method to the relevant `services/*.ts` class
+2. Call `server.registerTool('namespace.action', { description, inputSchema }, handler)` in `index.ts`
+3. Use zod for `inputSchema` — see existing tools for patterns
+4. Add a test in `__tests__/services/`
+
+## MCP Resources Available (when server is running)
+
+Load these to get behavioral guidance for using the extension:
+
+- `workspace://context` — Core behavioral guide
+- `workspace://skills/gmail`, `workspace://skills/google-docs`, etc.
+
+See [AGENT-CONTEXT.md](../../AGENT-CONTEXT.md) for the full behavioral guide.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,163 @@
+# GitHub Copilot Instructions
+
+## Project Overview
+
+This is a **Google Workspace Extension for Gemini CLI** — an MCP (Model Context Protocol) server that exposes Google Workspace APIs (Docs, Sheets, Slides, Gmail, Drive, Calendar, Chat, People) as tools callable by AI assistants via stdio transport.
+
+## Build, Test, and Lint
+
+```bash
+# Install dependencies
+npm install
+
+# Build (esbuild bundles workspace-server/src into workspace-server/dist)
+npm run build
+
+# Run all tests (Jest + ts-jest, runs from repo root)
+npm test
+
+# Run a single test file
+npx jest workspace-server/src/__tests__/services/DocsService.test.ts
+
+# Run tests matching a name pattern
+npx jest --testNamePattern "should create document"
+
+# Lint (TypeScript ESLint, applies only to workspace-server/src/**/*.ts)
+npm run lint
+npm run lint:fix
+
+# Format (Prettier)
+npm run format:check
+npm run format:fix
+
+# Before submitting a PR
+npm run test && npm run lint
+```
+
+> Tests run from the repo root even when invoked from `workspace-server/`. The `test` script in `workspace-server/package.json` does `cd ..` before running Jest.
+
+## Architecture
+
+### Two-Layer Structure
+
+The repo has two distinct layers:
+
+1. **`workspace-server/`** — The MCP server (TypeScript, compiled with esbuild). This is the core implementation.
+2. **`commands/` + `skills/`** — Gemini CLI extension artifacts (`.toml` command definitions and `SKILL.md` behavior guides). These are consumed by the Gemini CLI, not by the MCP server.
+
+### MCP Server (`workspace-server/src/`)
+
+- **`index.ts`** — Single entry point. Creates `McpServer`, instantiates all service classes, and registers 100+ tools via `server.registerTool()`. All tool names use dot notation (e.g., `docs.create`, `gmail.search`).
+- **`services/`** — One class per Google Workspace service (`DocsService`, `GmailService`, etc.). Each receives `AuthManager` in its constructor and exposes public methods that map 1:1 to registered MCP tools.
+- **`auth/AuthManager.ts`** — Orchestrates OAuth 2.0. Uses a hybrid token storage: OS keychain (primary) → AES-256-GCM encrypted file (fallback).
+- **`utils/`** — Shared helpers: `IdUtils.ts` (extracts IDs from Google URLs), `DriveQueryBuilder.ts`, `tool-normalization.ts` (converts tool names between dot and underscore formats for MCP compatibility), `logger.ts`, `validation.ts`.
+
+### Adding a New Tool
+
+1. Add a method to the relevant service in `workspace-server/src/services/`.
+2. Register it in `workspace-server/src/index.ts` via `server.registerTool('namespace.action', { description, inputSchema }, handler)`.
+3. Input schemas use **zod** — see existing tools for patterns.
+4. Add a corresponding test in `workspace-server/src/__tests__/services/`.
+
+### `commands/` and `skills/`
+
+- **`commands/<service>/<name>.toml`** — Defines Gemini CLI slash commands with a `description` and `prompt` template. The `prompt` field contains LLM instructions using `{{args}}` for user input.
+- **`skills/<service>/SKILL.md`** — Detailed behavioral guides loaded by Gemini when a relevant skill is activated. These override default AI behavior for that service (e.g., the Google Docs skill mandates a two-step create-then-format workflow).
+
+### `cloud_function/`
+
+Standalone Google Cloud Function (Node.js, no TypeScript) that handles the OAuth 2.0 callback redirect and stores credentials in Google Cloud Secret Manager. Independent from the MCP server.
+
+## Key Conventions
+
+### License Header Requirement
+
+**Every `.ts` file must start with this license header** (enforced by ESLint `eslint-plugin-headers`):
+
+```typescript
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+```
+
+The year must match `202[5-6]`. `workspace-server/src/index.ts` is exempt (has a shebang line).
+
+### Node Protocol Imports
+
+All Node.js built-in imports must use the `node:` protocol (enforced by ESLint):
+
+```typescript
+// ✅ Correct
+import { readFile } from 'node:fs/promises';
+
+// ❌ Wrong
+import { readFile } from 'fs/promises';
+```
+
+### Path Alias
+
+`@/` maps to `workspace-server/src/` in both TypeScript and Jest:
+
+```typescript
+import { something } from '@/utils/constants';
+```
+
+### Service Method Pattern
+
+Service methods are arrow functions assigned to public class properties (not regular methods), so they can be passed directly as MCP tool handlers without binding:
+
+```typescript
+export class ExampleService {
+  constructor(private authManager: AuthManager) {}
+
+  public doSomething = async ({ param }: { param: string }) => {
+    const client = await this.getClient();
+    // ...
+  };
+
+  private async getClient() { /* ... */ }
+}
+```
+
+### Test Structure
+
+Tests live in `workspace-server/src/__tests__/`, mirroring the source structure:
+
+- `__tests__/services/` → tests for `services/`
+- `__tests__/auth/` → tests for `auth/`
+- `__tests__/utils/` → tests for `utils/`
+- `__tests__/mocks/` → shared mock data and stubs
+
+Test files use `.test.ts` suffix. The `setup.ts` file silences `console.log/info/debug` during tests (errors and warnings are kept).
+
+### Build System
+
+The project uses **esbuild** (not `tsc`) to bundle the server into a single `workspace-server/dist/index.js`. The TypeScript compiler is used only for type-checking via ts-jest in tests. The root `tsconfig.json` has `strict: false` in the Jest configuration.
+
+### Unused Variables
+
+Prefix unused variables/parameters with `_` to suppress the ESLint warning:
+
+```typescript
+async function handler(_req: Request, res: Response) { ... }
+```
+
+## MCP Resources
+
+The server exposes MCP resources for behavioral guidance, accessible to any
+resource-capable MCP client:
+
+- `workspace://context` — Core behavioral guide (`WORKSPACE-Context.md`)
+- `workspace://skills/gmail` — Gmail guide
+- `workspace://skills/google-docs` — Docs guide
+- `workspace://skills/google-calendar` — Calendar guide
+- `workspace://skills/google-chat` — Chat guide
+- `workspace://skills/google-sheets` — Sheets guide
+- `workspace://skills/google-slides` — Slides guide
+
+For VS Code Copilot as an MCP client, configure the server in `.vscode/mcp.json`
+(see `docs/mcp-clients.md`). The `workspace://context` resource provides the
+same behavioral guidance as `WORKSPACE-Context.md`.
+

--- a/.github/plans/agent-agnostic.md
+++ b/.github/plans/agent-agnostic.md
@@ -1,0 +1,81 @@
+# Plan: Make Google Workspace Extension Agent-Agnostic
+
+## Problem Statement
+
+The MCP server (`workspace-server/`) already speaks standard MCP over stdio and is fully agent-agnostic at the protocol level. However, all installation docs, the README, and supporting files assume Gemini CLI as the only client. Additionally, other agents cannot benefit from the rich behavioral guidance in `skills/` and `WORKSPACE-Context.md` since those are loaded by Gemini's native skills system.
+
+We need to:
+1. Document how to connect this server to other major MCP-capable agents
+2. Make the skills/behavioral guidance accessible to those agents via their native mechanisms
+
+## How Skills Work Today (Gemini) vs. Other Agents
+
+| Layer | Gemini CLI | Other agents |
+|---|---|---|
+| MCP server config | `gemini-extension.json` | Agent-specific config file/settings |
+| Behavioral context | `WORKSPACE-Context.md` (auto-loaded) | Agent instruction file (CLAUDE.md, .cursorrules, etc.) |
+| Contextual skills | `skills/*/SKILL.md` (auto-activated by Gemini) | MCP Resources (served by server) + agent instruction files |
+
+## Approach
+
+Three-pronged strategy:
+
+### 1. MCP Resources (server-side, ~1 file change)
+Add MCP resource handlers to `workspace-server/src/index.ts` to expose behavioral content that any resource-capable agent can load:
+- `workspace://context` → contents of `WORKSPACE-Context.md`
+- `workspace://skills/{name}` → contents of each `skills/*/SKILL.md` (gmail, google-docs, google-calendar, google-chat, google-sheets, google-slides)
+
+This is a small addition to `index.ts` using the existing `@modelcontextprotocol/sdk`. The resources are read from the filesystem at runtime (paths relative to the built binary).
+
+### 2. Agent-Specific Instruction Files (new files)
+Create instruction files for each major agent at the repo root or standard paths. These files contain the consolidated behavioral guidance from `WORKSPACE-Context.md` + skill highlights, adapted for each agent's format:
+
+| Agent | File |
+|---|---|
+| Claude Desktop / Claude Code | `CLAUDE.md` |
+| Cursor | `.cursor/rules/google-workspace.md` |
+| Cline | `.clinerules` |
+| Windsurf | `.windsurfrules` |
+| VS Code Copilot | `.github/copilot-instructions.md` (already exists — update) |
+| Continue.dev | Documented in `docs/mcp-clients.md` as a system prompt paste |
+
+Content strategy: Rather than copy/pasting all skill content into every file (unmaintainable), create a **single `AGENT-CONTEXT.md`** at the repo root as the canonical consolidated behavioral guide for non-Gemini agents. Agent-specific files reference this file and add any agent-specific setup notes. 
+
+### 3. Installation Docs (new docs page)
+Create `docs/mcp-clients.md` covering all 6 agents with:
+- Prerequisites + build + auth (shared section)
+- Per-agent: MCP config snippet, how behavioral context is loaded, tool naming note
+
+## Agents to Cover
+
+1. **Claude Desktop** — `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS) / `%APPDATA%\Claude\claude_desktop_config.json` (Windows)
+2. **VS Code Copilot** — `.vscode/mcp.json` or workspace settings
+3. **Cursor** — `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` (project)
+4. **Cline** — VS Code extension MCP settings
+5. **Continue.dev** — `~/.continue/config.json` mcpServers block
+6. **Windsurf** — `~/.codeium/windsurf/mcp_config.json`
+
+## Key Technical Notes (for all docs)
+
+- **Tool naming**: By default the server uses underscore format (`docs_create`). The `--use-dot-names` flag is Gemini-only. All other agents work with the default.
+- **Auth**: All agents use the same `node scripts/auth-utils.js login` flow.
+- **Prerequisites**: Node.js ≥ 20, repo cloned + `npm install && npm run build`.
+- **MCP Resources**: Agents that support resource loading (Claude Desktop, Cline) can load skills on demand. Those that don't will rely on the agent instruction file.
+
+## Todos
+
+1. Research exact MCP config file paths/format for all 6 agents (and resource loading support per agent)
+2. Add MCP resource handlers to `workspace-server/src/index.ts` (serve WORKSPACE-Context.md + skills as resources)
+3. Add tests for MCP resource serving (in `workspace-server/src/__tests__/`)
+4. Create `AGENT-CONTEXT.md` — consolidated behavioral guide (no Gemini-specific references)
+5. Create agent instruction files: `CLAUDE.md`, `.cursor/rules/google-workspace.md`, `.clinerules`, `.windsurfrules`; update `.github/copilot-instructions.md`
+6. Create `docs/mcp-clients.md` with per-agent setup guide (config + behavioral context + tool naming)
+7. Update `README.md` — add "Other MCP Clients" section, link to `docs/mcp-clients.md`
+8. Update `docs/index.md` — link to new page
+9. Update `docs/.vitepress/config.*` — add `mcp-clients.md` to sidebar/nav
+
+## Not Changing
+
+- `gemini-extension.json`, `commands/`, `skills/`, `WORKSPACE-Context.md`, `GEMINI.md` — Gemini support stays as-is
+- Release artifact (tarball) — Gemini-specific, no change needed
+- Token storage names, env vars — out of scope

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ coverage/
 *~
 .idea/
 .vscode/
+!.vscode/mcp.json
 
 # Auth tokens
 token.json

--- a/.vscode/mcp.json
+++ b/.vscode/mcp.json
@@ -1,0 +1,9 @@
+{
+  "servers": {
+    "google-workspace": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["workspace-server/dist/index.js"]
+    }
+  }
+}

--- a/.windsurfrules
+++ b/.windsurfrules
@@ -1,0 +1,46 @@
+# Google Workspace MCP Server
+
+This is a Google Workspace Extension providing MCP tools for Docs, Sheets,
+Slides, Gmail, Drive, Calendar, Chat, and People APIs via the Model Context
+Protocol (MCP).
+
+## Build & Test
+
+```bash
+npm install && npm run build   # install and build
+npm test                       # run all tests
+npx jest <path/to/test.ts>     # run a single test
+npm run lint && npm run lint:fix
+```
+
+## Development Conventions
+
+- Entry point: `workspace-server/src/index.ts` (registers all MCP tools)
+- Services: `workspace-server/src/services/` (one file per Google service)
+- Tests: `workspace-server/src/__tests__/services/` (mirrors services/)
+- Every `.ts` file needs the Apache 2.0 license header
+- Node.js imports must use the `node:` prefix (e.g., `node:fs`, `node:path`)
+- Unused vars/params must be prefixed with `_`
+- Service methods are arrow functions on class properties (not regular methods)
+
+## Adding a New Tool
+
+1. Add an arrow-function method to the relevant `services/*.ts` class
+2. Call `server.registerTool('namespace.action', { description, inputSchema }, handler)` in `index.ts`
+3. Use zod for `inputSchema` — see existing tools for patterns
+4. Add a test in `__tests__/services/`
+
+## MCP Resources Available (when server is running)
+
+When the MCP server is configured and running, load these resources for
+behavioral guidance before working with each service:
+
+- `workspace://context` — Core behavioral guide (load at session start)
+- `workspace://skills/gmail` — Gmail composition and search guide
+- `workspace://skills/google-docs` — Docs two-step format workflow
+- `workspace://skills/google-calendar` — Calendar timezone-first workflow
+- `workspace://skills/google-chat` — Chat message formatting guide
+- `workspace://skills/google-sheets` — Sheets query and range guide
+- `workspace://skills/google-slides` — Slides extraction guide
+
+See [AGENT-CONTEXT.md](AGENT-CONTEXT.md) for a full standalone behavioral guide.

--- a/AGENT-CONTEXT.md
+++ b/AGENT-CONTEXT.md
@@ -1,0 +1,192 @@
+# Google Workspace MCP Server — Behavioral Guide
+
+This guide provides behavioral instructions for effectively using the Google
+Workspace MCP server. For detailed parameter documentation, refer to the tool
+descriptions in the server itself.
+
+## Core Principles
+
+### 1. User Context First
+
+**Always establish user context at the beginning of interactions:**
+
+- Use `people_getMe()` to understand who the user is
+- Use `time_getTimeZone()` to get the user's local timezone
+- Apply this context throughout all interactions
+- All time-based operations should respect the user's timezone
+
+### 2. Safety and Transparency
+
+**Never execute write operations without explicit confirmation:**
+
+- Preview all changes before executing
+- Show complete details in a readable format
+- Wait for clear user approval
+- Give users the opportunity to review and cancel
+
+### 3. Smart Tool Usage
+
+**Choose the right approach for each task:**
+
+- Tools automatically handle URL-to-ID conversion — don't extract IDs manually
+- Batch related operations when possible
+- Use pagination for large result sets
+- Apply appropriate formats based on the use case
+
+## Output Formatting Standards
+
+### Lists and Search Results
+
+Always format multiple items as **numbered lists** for better readability:
+
+✅ **Correct:**
+
+```
+Found 3 documents:
+1. Budget Report 2024
+2. Q3 Sales Presentation
+3. Team Meeting Notes
+```
+
+❌ **Incorrect:**
+
+```
+Found 3 documents:
+- Budget Report 2024
+- Q3 Sales Presentation
+- Team Meeting Notes
+```
+
+### Write Operation Previews
+
+Before any write operation, show a clear preview:
+
+```
+I'll create this calendar event:
+
+Title: Team Standup
+Date: January 15, 2025
+Time: 10:00 AM - 10:30 AM (EST)
+Attendees: team@example.com
+
+Should I create this event?
+```
+
+## Tool Naming
+
+By default the server exposes tools using **underscore notation** (e.g.,
+`docs_create`, `gmail_search`). The tool descriptions in your agent will show
+the correct names automatically.
+
+## Multi-Tool Workflows
+
+### Creating and Organizing Documents
+
+When creating documents in specific folders:
+
+1. Create the document with `docs_create` (blank)
+2. Move it to the target folder with `drive_moveFile`
+3. Confirm successful completion
+
+To find Google Docs, Sheets, or Slides, use `drive_search` with a MIME type
+filter rather than searching by name alone. Example MIME type queries:
+
+- Docs: `mimeType='application/vnd.google-apps.document' and name contains 'query'`
+- Sheets: `mimeType='application/vnd.google-apps.spreadsheet' and name contains 'query'`
+- Slides: `mimeType='application/vnd.google-apps.presentation' and name contains 'query'`
+
+## Error Handling
+
+### Authentication Errors
+
+- If any tool returns `{"error":"invalid_request"}`, it likely indicates an
+  expired or invalid session.
+- **Action:** Call `auth_clear` to reset credentials and force a re-login.
+
+### Graceful Degradation
+
+- If a folder doesn't exist, offer to create it
+- If search returns no results, suggest alternatives
+- If permissions are insufficient, explain clearly
+
+### Validation Before Action
+
+- Verify file/folder existence before moving
+- Check calendar availability before scheduling
+- Validate email addresses before sending
+
+## Common Pitfalls to Avoid
+
+- ❌ Try to extract IDs manually from URLs — tools accept URLs directly
+- ❌ Assume timezone without checking via `time_getTimeZone`
+- ❌ Execute write operations without preview and confirmation
+- ❌ Create files unless explicitly requested
+- ❌ Use relative paths for file downloads
+
+## Session Management
+
+### Beginning of Session
+
+1. Get user profile with `people_getMe()`
+2. Get timezone with `time_getTimeZone()`
+3. Establish any relevant context
+
+### End of Session
+
+- Confirm all requested tasks completed
+- Provide summary if multiple operations performed
+- Ensure no pending confirmations
+
+## Service-Specific Guidance
+
+### Google Docs
+
+Use a **two-step workflow** for richly formatted documents:
+
+1. **Insert content** using `docs_create` or `docs_writeText` — inserts plain text
+2. **Apply formatting** using `docs_formatText` — applies bold, italic, headings, links
+
+Indices are 1-based. Calculate character positions carefully, counting newlines.
+
+Multiple styles can stack: apply both `heading2` and `bold` to the same range.
+
+### Gmail
+
+When composing emails (via `gmail_send` or `gmail_createDraft`), **always use
+HTML formatting with `isHtml: true`** unless the user explicitly requests plain
+text. Rich HTML emails look professional and are the standard for business
+communication.
+
+Use `gmail_search` with Gmail search syntax (e.g., `from:someone@example.com`,
+`is:unread`, `subject:meeting`).
+
+### Google Calendar
+
+**Always call `time_getTimeZone()` before any calendar operation.** Use the
+returned timezone for all event creation and display. ISO 8601 datetimes must
+include a timezone offset (e.g., `2025-01-15T10:30:00-05:00`) — never send
+"bare" datetimes without an offset.
+
+Always pass `calendarId: "primary"` on every calendar tool call that accepts a
+`calendarId` parameter.
+
+### Google Chat
+
+When composing messages (via `chat_sendMessage` or `chat_sendDm`), use Google
+Chat's supported markdown syntax. Use `**bold**`, `_italic_`, `` `code` ``, and
+```` ```code blocks``` ```` — do NOT use standard markdown like `# headings` or
+`---` dividers, which are not supported.
+
+### Google Sheets
+
+Use `sheets_getText` for an overview of spreadsheet content, and `sheets_getRange`
+for specific data ranges. MIME type filter for finding sheets:
+`mimeType='application/vnd.google-apps.spreadsheet'`
+
+### Google Slides
+
+Use `slides_getText` to extract all text. For images, use `slides_getImages`
+to download all embedded images to a local directory. Use
+`slides_getSlideThumbnail` for a single slide's thumbnail. MIME type filter
+for finding presentations:
+`mimeType='application/vnd.google-apps.presentation'`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,49 @@
+# Google Workspace MCP Server — Claude Guide
+
+This is a Google Workspace Extension that provides tools for interacting with
+Google Workspace services (Docs, Sheets, Slides, Gmail, Drive, Calendar, Chat,
+People) via the Model Context Protocol (MCP).
+
+## Building and Running
+
+- **Install dependencies:** `npm install`
+- **Build the project:** `npm run build`
+- **Run tests:** `npm test`
+- **Lint:** `npm run lint`
+
+## Development Conventions
+
+This project uses TypeScript and the MCP SDK. The main entry point is
+`workspace-server/src/index.ts`, which initializes the MCP server and registers
+all tools.
+
+Business logic for each service lives in `workspace-server/src/services/`.
+Authentication is handled by `workspace-server/src/auth/AuthManager.ts`.
+
+All source files must start with the Apache 2.0 license header. Node.js
+built-ins must use the `node:` protocol prefix (e.g., `import from 'node:fs'`).
+
+## Adding New Tools
+
+1. Add a method to the appropriate service in `workspace-server/src/services/`.
+2. Register it in `workspace-server/src/index.ts` via `server.registerTool()`.
+3. Add a test in `workspace-server/src/__tests__/services/`.
+
+## Using This Extension as an MCP Client
+
+If you have this MCP server configured and running, the following MCP resources
+are available to load behavioral guidance into your context:
+
+- `workspace://context` — Core behavioral guide (best practices, formatting, error handling)
+- `workspace://skills/gmail` — Gmail composition and search guide
+- `workspace://skills/google-docs` — Google Docs two-step format workflow
+- `workspace://skills/google-calendar` — Calendar timezone-first workflow
+- `workspace://skills/google-chat` — Chat message formatting guide
+- `workspace://skills/google-sheets` — Sheets query and range guide
+- `workspace://skills/google-slides` — Slides text extraction and image guide
+
+Load `workspace://context` at the start of a session for general guidance, and
+load the relevant skill resource before working with a specific service.
+
+See [AGENT-CONTEXT.md](AGENT-CONTEXT.md) for a standalone copy of the
+behavioral guide that can be pasted as a system prompt.

--- a/README.md
+++ b/README.md
@@ -2,9 +2,12 @@
 
 [![Build Status](https://github.com/gemini-cli-extensions/workspace/actions/workflows/ci.yml/badge.svg)](https://github.com/gemini-cli-extensions/workspace/actions/workflows/ci.yml)
 
-The Google Workspace extension for Gemini CLI brings the power of your Google
-Workspace apps to your command line. Manage your documents, spreadsheets,
-presentations, emails, chat, and calendar events without leaving your terminal.
+The Google Workspace extension brings the power of your Google Workspace apps
+to your command line. Manage your documents, spreadsheets, presentations,
+emails, chat, and calendar events without leaving your terminal.
+
+This extension works as a [Model Context Protocol](https://modelcontextprotocol.io/)
+(MCP) server compatible with **Gemini CLI** and any other MCP-capable agent.
 
 ## Prerequisites
 
@@ -13,12 +16,22 @@ Google account.
 
 ## Installation
 
+### Gemini CLI
+
 Install the Google Workspace extension by running the following command from
 your terminal:
 
 ```bash
 gemini extensions install https://github.com/gemini-cli-extensions/workspace
 ```
+
+### Other MCP Clients
+
+This server works with Claude Desktop, VS Code Copilot, Cursor, Cline,
+Continue.dev, Windsurf, and any other MCP-compatible agent.
+
+See the **[MCP Clients Setup Guide](docs/mcp-clients.md)** for per-agent
+configuration instructions.
 
 ## Usage
 
@@ -78,6 +91,8 @@ If you want to host your own version of this extension's infrastructure, see the
 
 - [Documentation](docs/index.md): Detailed documentation on all the available
   tools.
+- [MCP Clients Setup](docs/mcp-clients.md): Instructions for Claude Desktop,
+  VS Code Copilot, Cursor, Cline, Continue.dev, and Windsurf.
 - [GitHub Issues](https://github.com/gemini-cli-extensions/workspace/issues):
   Report bugs or request features.
 
@@ -98,7 +113,7 @@ Google Account data, as well as other data shared with you.
 - Untrusted inputs may contain hidden instructions that could hijack your CLI
   session. Attackers can then leverage this to modify, steal, or destroy your
   data.
-- Always carefully review actions taken by Gemini CLI on your behalf to ensure
+- Always carefully review actions taken by your AI agent on your behalf to ensure
   they are correct and align with your intentions.
 
 ## Contributing

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -9,6 +9,7 @@ export default defineConfig({
     // https://vitepress.dev/reference/default-theme-config
     nav: [
       { text: 'Home', link: '/' },
+      { text: 'MCP Clients', link: '/mcp-clients' },
       { text: 'Development', link: '/development' },
       { text: 'Release', link: '/release' },
       { text: 'Release Notes', link: '/release_notes' },
@@ -19,6 +20,7 @@ export default defineConfig({
         text: 'Documentation',
         items: [
           { text: 'Overview', link: '/' },
+          { text: 'MCP Clients Setup', link: '/mcp-clients' },
           { text: 'Development Guide', link: '/development' },
           { text: 'GCP Setup Guide', link: '/GCP-RECREATION' },
           { text: 'Release Guide', link: '/release' },

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,12 @@
 # Google Workspace Extension Documentation
 
-This document provides an overview of the Google Workspace extension for Gemini
-CLI.
+This document provides an overview of the Google Workspace MCP server — a
+[Model Context Protocol](https://modelcontextprotocol.io/) server that exposes
+Google Workspace APIs as tools callable by AI assistants.
+
+The server works with **Gemini CLI** and any other MCP-compatible agent. See
+[Using with Other MCP Clients](mcp-clients.md) for setup instructions for
+Claude Desktop, VS Code Copilot, Cursor, Cline, Continue.dev, and Windsurf.
 
 ## Available Tools
 

--- a/docs/mcp-clients.md
+++ b/docs/mcp-clients.md
@@ -1,0 +1,257 @@
+# Using with Other MCP Clients
+
+The Google Workspace MCP server speaks standard
+[Model Context Protocol](https://modelcontextprotocol.io/) over stdio, so it
+works with any MCP-compatible agent — not just Gemini CLI.
+
+## Prerequisites
+
+All agents require the same setup:
+
+1. **Node.js ≥ 20** installed
+2. **Clone and build the server:**
+   ```bash
+   git clone https://github.com/gemini-cli-extensions/workspace.git
+   cd workspace
+   npm install && npm run build
+   ```
+3. **Authenticate with Google:**
+   ```bash
+   node scripts/auth-utils.js login
+   ```
+   Follow the printed URL to sign in. On headless/SSH environments, paste the
+   credentials JSON when prompted. See the
+   [authentication docs](development.md#authentication) for full details.
+
+> **Note for Windows users:** Use backslashes in paths within JSON config files,
+> e.g. `C:\\Users\\you\\workspace\\workspace-server\\dist\\index.js`.
+
+## Tool Naming
+
+By default the server uses **underscore notation** for tool names (e.g.,
+`docs_create`, `gmail_search`). This is the format expected by all agents below.
+
+> **Gemini CLI only:** The `--use-dot-names` flag switches to dot notation
+> (`docs.create`). Do not pass this flag when using other agents.
+
+## Behavioral Guidance and Skills
+
+Gemini CLI activates per-service skill files automatically. For other agents,
+equivalent guidance is available as **MCP resources** served by the server:
+
+| Resource URI | Contents |
+|---|---|
+| `workspace://context` | Core behavioral guide (best practices, formatting, error handling) |
+| `workspace://skills/gmail` | Gmail composition, HTML email, search syntax |
+| `workspace://skills/google-docs` | Two-step create-then-format workflow |
+| `workspace://skills/google-calendar` | Timezone-first workflow, ISO 8601 requirements |
+| `workspace://skills/google-chat` | Supported markdown syntax |
+| `workspace://skills/google-sheets` | Spreadsheet querying and ranges |
+| `workspace://skills/google-slides` | Text extraction, images, thumbnails |
+
+Load `workspace://context` at the start of each session. Load a skill resource
+before working with a specific service.
+
+For agents that don't support MCP resources, you can paste the contents of
+[AGENT-CONTEXT.md](https://github.com/gemini-cli-extensions/workspace/blob/main/AGENT-CONTEXT.md)
+as a system prompt.
+
+---
+
+## Claude Desktop
+
+**Config file:**
+- macOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
+- Windows: `%APPDATA%\Claude\claude_desktop_config.json`
+
+Add the following to your config (replace the path with the absolute path to
+your cloned repo):
+
+```json
+{
+  "mcpServers": {
+    "google-workspace": {
+      "command": "node",
+      "args": ["/absolute/path/to/workspace/workspace-server/dist/index.js"]
+    }
+  }
+}
+```
+
+Restart Claude Desktop after saving. The `google-workspace` server will appear
+in the Claude UI. Claude Desktop supports MCP resources — load
+`workspace://context` at the start of your session.
+
+---
+
+## GitHub Copilot CLI
+
+**Config files** (merged in priority order, highest first):
+1. `.copilot/mcp-config.json` — project/repo level (commit this to share with your team)
+2. `~/.copilot/mcp-config.json` — user level (applies to all projects)
+3. `.vscode/mcp.json` — also read as a fallback
+
+**Recommended:** add `.copilot/mcp-config.json` to the repo root so the server
+is available whenever you open the repo in Copilot CLI.
+
+```json
+{
+  "mcpServers": {
+    "google-workspace": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/absolute/path/to/workspace/workspace-server/dist/index.js"]
+    }
+  }
+}
+```
+
+Use `/mcp` inside a Copilot CLI session to list, add, or refresh MCP servers
+without restarting. After adding the config file, run `/mcp` to confirm
+`google-workspace` appears in the list.
+
+> Copilot CLI also reads `CLAUDE.md` and `GEMINI.md` from the repo root — both
+> files exist in this repo and provide development guidance automatically.
+
+---
+
+## GitHub Copilot (VS Code)
+
+**Config file:**
+- Workspace: `.vscode/mcp.json` (commit this to share with your team — also read by Copilot CLI as a fallback)
+- User-level: `%APPDATA%\Code\User\mcp.json` (Windows) or
+  `~/.config/Code/User/mcp.json` (macOS/Linux)
+
+> **Schema difference:** VS Code Copilot uses `"servers"` (not `"mcpServers"`)
+> while Copilot CLI uses `"mcpServers"`. Both require `"type": "stdio"`. Keep
+> separate files if you want both to work reliably.
+
+```json
+{
+  "servers": {
+    "google-workspace": {
+      "type": "stdio",
+      "command": "node",
+      "args": ["/absolute/path/to/workspace/workspace-server/dist/index.js"]
+    }
+  }
+}
+```
+
+Alternatively, run **MCP: Open User Configuration** from the VS Code Command
+Palette to open or create the file.
+
+---
+
+## Cursor
+
+**Config file:**
+- Global: `~/.cursor/mcp.json` (macOS/Linux) or `%APPDATA%\Cursor\mcp.json` (Windows)
+- Project: `.cursor/mcp.json` (project-level, takes priority over global)
+
+```json
+{
+  "mcpServers": {
+    "google-workspace": {
+      "command": "node",
+      "args": ["/absolute/path/to/workspace/workspace-server/dist/index.js"]
+    }
+  }
+}
+```
+
+Restart Cursor after saving. Project-level configs override global ones.
+
+---
+
+## Cline
+
+Cline stores MCP server configuration in a dedicated settings file managed by
+the VS Code extension:
+
+- macOS: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+- Windows: `%APPDATA%\Code\User\globalStorage\saoudrizwan.claude-dev\settings\cline_mcp_settings.json`
+- Linux: `~/.config/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+
+**Recommended:** Use the Cline UI to add the server:
+1. Click the **MCP Servers** icon in the Cline sidebar
+2. Select the **Configure** tab → **Configure MCP Servers**
+3. Add the following entry:
+
+```json
+{
+  "mcpServers": {
+    "google-workspace": {
+      "command": "node",
+      "args": ["/absolute/path/to/workspace/workspace-server/dist/index.js"],
+      "disabled": false,
+      "alwaysAllow": []
+    }
+  }
+}
+```
+
+---
+
+## Continue.dev
+
+**Config file:**
+- macOS/Linux: `~/.continue/config.json`
+- Windows: `%USERPROFILE%\.continue\config.json`
+- Project-level: `.continue/config.json`
+
+Add a `mcpServers` block to your existing config:
+
+```json
+{
+  "mcpServers": [
+    {
+      "name": "google-workspace",
+      "command": "node",
+      "args": ["/absolute/path/to/workspace/workspace-server/dist/index.js"]
+    }
+  ]
+}
+```
+
+---
+
+## Windsurf
+
+**Config file:**
+- macOS/Linux: `~/.codeium/windsurf/mcp_config.json`
+- Windows: `%USERPROFILE%\.codeium\windsurf\mcp_config.json`
+
+You can open this file from within Windsurf: click the MCP icon in the toolbar
+and select **Configure**. Add the following:
+
+```json
+{
+  "mcpServers": {
+    "google-workspace": {
+      "command": "node",
+      "args": ["/absolute/path/to/workspace/workspace-server/dist/index.js"]
+    }
+  }
+}
+```
+
+Restart Windsurf after saving.
+
+---
+
+## Troubleshooting
+
+**Server doesn't appear after configuration:**
+- Ensure the path to `dist/index.js` is absolute, not relative
+- Verify the build succeeded: `ls workspace-server/dist/index.js`
+- Check that Node.js ≥ 20 is on your PATH
+
+**Authentication errors (`{"error":"invalid_request"}`):**
+- Run `node scripts/auth-utils.js status` to check credential status
+- Run `node scripts/auth-utils.js clear` then re-authenticate with `node scripts/auth-utils.js login`
+
+**Tools not listed:**
+- Some agents require a restart after adding MCP servers
+- Verify the server starts correctly: `node workspace-server/dist/index.js`
+  (it should print a ready message to stderr)

--- a/workspace-server/src/__tests__/resources.test.ts
+++ b/workspace-server/src/__tests__/resources.test.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+jest.mock('node:fs');
+
+const mockExistsSync = existsSync as jest.MockedFunction<typeof existsSync>;
+const mockReadFileSync = readFileSync as jest.MockedFunction<typeof readFileSync>;
+
+describe('MCP resource path resolution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('resolves WORKSPACE-Context.md relative to __dirname parent', () => {
+    // Simulates workspace-server/dist/index.js looking for WORKSPACE-Context.md
+    const simulatedDirname = '/project/workspace-server/dist';
+    const contextPath = join(simulatedDirname, '..', 'WORKSPACE-Context.md');
+    expect(contextPath).toContain('workspace-server');
+    expect(contextPath).toContain('WORKSPACE-Context.md');
+  });
+
+  it('finds skills dir in release layout (dist/../skills)', () => {
+    const simulatedDirname = '/project/dist';
+    const releasePath = join(simulatedDirname, '..', 'skills');
+    const devPath = join(simulatedDirname, '..', '..', 'skills');
+
+    mockExistsSync.mockImplementation((p) => p === releasePath);
+
+    const skillsBaseDir = [releasePath, devPath].find((d) =>
+      mockExistsSync(d),
+    );
+    expect(skillsBaseDir).toBe(releasePath);
+  });
+
+  it('finds skills dir in dev layout (dist/../../skills)', () => {
+    const simulatedDirname = '/project/workspace-server/dist';
+    const releasePath = join(simulatedDirname, '..', 'skills');
+    const devPath = join(simulatedDirname, '..', '..', 'skills');
+
+    mockExistsSync.mockImplementation((p) => p === devPath);
+
+    const skillsBaseDir = [releasePath, devPath].find((d) =>
+      mockExistsSync(d),
+    );
+    expect(skillsBaseDir).toBe(devPath);
+  });
+
+  it('returns undefined when no skills directory is found', () => {
+    mockExistsSync.mockReturnValue(false);
+    const simulatedDirname = '/project/workspace-server/dist';
+    const paths = [
+      join(simulatedDirname, '..', 'skills'),
+      join(simulatedDirname, '..', '..', 'skills'),
+    ];
+    const skillsBaseDir = paths.find((d) => mockExistsSync(d));
+    expect(skillsBaseDir).toBeUndefined();
+  });
+
+  it('reads skill file content when path exists', () => {
+    const skillPath = '/project/skills/gmail/SKILL.md';
+    const expectedContent = '# Gmail Expert\n\nSome content here.';
+    mockExistsSync.mockReturnValue(true);
+    mockReadFileSync.mockReturnValue(expectedContent as any);
+
+    const content = existsSync(skillPath)
+      ? readFileSync(skillPath, 'utf-8')
+      : null;
+    expect(content).toBe(expectedContent);
+  });
+
+  it('skips skill registration when skill file does not exist', () => {
+    mockExistsSync.mockReturnValue(false);
+    const skillPath = '/project/skills/gmail/SKILL.md';
+
+    const content = existsSync(skillPath)
+      ? readFileSync(skillPath, 'utf-8')
+      : null;
+    expect(content).toBeNull();
+    expect(mockReadFileSync).not.toHaveBeenCalled();
+  });
+
+  it('covers all expected skill names', () => {
+    const expectedSkills = [
+      'gmail',
+      'google-docs',
+      'google-calendar',
+      'google-chat',
+      'google-sheets',
+      'google-slides',
+    ];
+
+    // Verify all skills have entries (sanity check on the list)
+    expect(expectedSkills).toHaveLength(6);
+    expectedSkills.forEach((name) => {
+      expect(name).toMatch(/^[a-z-]+$/);
+    });
+  });
+});

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -6,6 +6,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
 import { z } from 'zod';
@@ -1315,7 +1318,75 @@ System labels that can be modified:
     peopleService.getUserRelations,
   );
 
-  // 4. Connect the transport layer and start listening
+  // 4. Register MCP resources exposing behavioral context and per-service skill guides.
+  // Any MCP-compatible agent (Claude Desktop, Cursor, Cline, etc.) can load these
+  // to get the same behavioral guidance that Gemini CLI activates via its skills system.
+  const contextFilePath = join(__dirname, '..', 'WORKSPACE-Context.md');
+  if (existsSync(contextFilePath)) {
+    server.registerResource(
+      'workspace-context',
+      'workspace://context',
+      {
+        title: 'Google Workspace Behavioral Guide',
+        description:
+          'Core behavioral instructions for using the Google Workspace MCP server effectively, including best practices, output formatting, and error handling patterns.',
+        mimeType: 'text/markdown',
+      },
+      async (uri) => ({
+        contents: [
+          {
+            uri: uri.href,
+            mimeType: 'text/markdown',
+            text: readFileSync(contextFilePath, 'utf-8'),
+          },
+        ],
+      }),
+    );
+  }
+
+  // Skills may be in the release layout (dist/../skills) or dev layout (dist/../../skills)
+  const skillsBaseDir = [
+    join(__dirname, '..', 'skills'),
+    join(__dirname, '..', '..', 'skills'),
+  ].find((d) => existsSync(d));
+
+  const skillDefs = [
+    { name: 'gmail', title: 'Gmail Expert Guide' },
+    { name: 'google-docs', title: 'Google Docs Expert Guide' },
+    { name: 'google-calendar', title: 'Google Calendar Expert Guide' },
+    { name: 'google-chat', title: 'Google Chat Expert Guide' },
+    { name: 'google-sheets', title: 'Google Sheets Expert Guide' },
+    { name: 'google-slides', title: 'Google Slides Expert Guide' },
+  ];
+
+  if (skillsBaseDir) {
+    for (const skill of skillDefs) {
+      const skillPath = join(skillsBaseDir, skill.name, 'SKILL.md');
+      if (existsSync(skillPath)) {
+        const capturedPath = skillPath;
+        server.registerResource(
+          `skill-${skill.name}`,
+          `workspace://skills/${skill.name}`,
+          {
+            title: skill.title,
+            description: `Detailed behavioral guide for ${skill.title.replace(' Expert Guide', '')} operations through the MCP server.`,
+            mimeType: 'text/markdown',
+          },
+          async (uri) => ({
+            contents: [
+              {
+                uri: uri.href,
+                mimeType: 'text/markdown',
+                text: readFileSync(capturedPath, 'utf-8'),
+              },
+            ],
+          }),
+        );
+      }
+    }
+  }
+
+  // 5. Connect the transport layer and start listening
   const transport = new StdioServerTransport();
   await server.connect(transport);
 


### PR DESCRIPTION
- Add MCP resources (workspace://context, workspace://skills/*) so any resource-capable agent can load behavioral guidance from the server
- Add agent instruction files: CLAUDE.md, .clinerules, .windsurfrules, .cursor/rules/google-workspace.md, .github/copilot-instructions.md
- Add AGENT-CONTEXT.md as consolidated behavioral guide for non-Gemini agents
- Add MCP client configs: .copilot/mcp-config.json (Copilot CLI), .vscode/mcp.json (VS Code Copilot)
- Add docs/mcp-clients.md with per-agent setup guide (Claude Desktop, VS Code Copilot, Cursor, Cline, Continue.dev, Windsurf)
- Update README.md to mention MCP compatibility and link to setup guide
- Update docs nav/sidebar to include new MCP Clients page
- Add tests for MCP resource path resolution