### PR TITLE
feat: multi-account profile support via WORKSPACE_PROFILE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,59 @@
+# google-workspace-mcp
+
+> Google Workspace MCP server -- Gmail, Docs, Sheets, Slides, Drive, Calendar, and Chat from the command line.
+
+## Ecosystem Context
+See `~/.claude/ecosystem-map.md` for cross-repo relationships.
+
+## Quick Reference
+- **Stack:** TypeScript / Node.js (MCP SDK)
+- **Upstream:** `gemini-cli-extensions/workspace`
+- **Status:** active (fork with multi-account support)
+- **Org:** leegonzales
+
+## Fork Changes (vs upstream)
+
+### Multi-Account Profile Support
+
+Upstream hardcodes a single keychain service name, so only one Google account can be authenticated at a time. Our fork adds `WORKSPACE_PROFILE` env var support.
+
+**How it works:**
+- No env var → keychain service: `gemini-cli-workspace-oauth` (default, backward-compatible)
+- `WORKSPACE_PROFILE=personal` → keychain service: `gemini-cli-workspace-oauth-personal`
+- `WORKSPACE_PROFILE=anything` → keychain service: `gemini-cli-workspace-oauth-anything`
+
+Each profile gets its own credential slot in macOS Keychain, so multiple Google accounts coexist.
+
+**Files changed:**
+- `workspace-server/src/utils/config.ts` — added `profile` to `WorkspaceConfig`, reads `WORKSPACE_PROFILE`
+- `workspace-server/src/auth/token-storage/oauth-credential-storage.ts` — keychain service name derived from profile
+
+### Claude Code MCP Configuration
+
+In `~/.claude/settings.json`, configure one server entry per account:
+
+```json
+{
+  "mcpServers": {
+    "google-workspace-personal": {
+      "command": "node",
+      "args": ["<path>/workspace-server/dist/index.js"],
+      "env": { "WORKSPACE_PROFILE": "personal" }
+    }
+  }
+}
+```
+
+The default (no profile) instance is used for Catalyst (`lee@catalystai.services`). The `personal` profile is for `lee.gonzales@gmail.com`.
+
+**First-time auth:** On first tool call, the server opens a browser for OAuth consent. Sign in with the appropriate Google account.
+
+### Syncing with Upstream
+
+```bash
+git fetch upstream
+git merge upstream/main
+npm run build
+```
+
+Profile support is isolated to two files, so merge conflicts should be rare.

--- a/workspace-server/src/auth/token-storage/oauth-credential-storage.ts
+++ b/workspace-server/src/auth/token-storage/oauth-credential-storage.ts
@@ -7,13 +7,21 @@
 import { type Credentials } from 'google-auth-library';
 import { HybridTokenStorage } from './hybrid-token-storage';
 import type { OAuthCredentials } from './types';
+import { loadConfig } from '../../utils/config';
 
-const KEYCHAIN_SERVICE_NAME = 'gemini-cli-workspace-oauth';
+const BASE_KEYCHAIN_SERVICE_NAME = 'gemini-cli-workspace-oauth';
 const MAIN_ACCOUNT_KEY = 'main-account';
+
+function getKeychainServiceName(): string {
+  const { profile } = loadConfig();
+  return profile
+    ? `${BASE_KEYCHAIN_SERVICE_NAME}-${profile}`
+    : BASE_KEYCHAIN_SERVICE_NAME;
+}
 
 export class OAuthCredentialStorage {
   private static storage: HybridTokenStorage = new HybridTokenStorage(
-    KEYCHAIN_SERVICE_NAME,
+    getKeychainServiceName(),
   );
 
   /**

--- a/workspace-server/src/utils/config.ts
+++ b/workspace-server/src/utils/config.ts
@@ -9,6 +9,7 @@ import { logToFile } from './logger';
 export interface WorkspaceConfig {
   clientId: string;
   cloudFunctionUrl: string;
+  profile: string;
 }
 
 const DEFAULT_CONFIG: WorkspaceConfig = {
@@ -22,11 +23,13 @@ const DEFAULT_CONFIG: WorkspaceConfig = {
  * to read from environment variables or a configuration file.
  */
 export function loadConfig(): WorkspaceConfig {
+  const profile = process.env['WORKSPACE_PROFILE'] || '';
   const config: WorkspaceConfig = {
     clientId: process.env['WORKSPACE_CLIENT_ID'] || DEFAULT_CONFIG.clientId,
     cloudFunctionUrl:
       process.env['WORKSPACE_CLOUD_FUNCTION_URL'] ||
       DEFAULT_CONFIG.cloudFunctionUrl,
+    profile,
   };
 
   const maskedClientId =
@@ -34,7 +37,7 @@ export function loadConfig(): WorkspaceConfig {
       ? `...${config.clientId.slice(-2)}`
       : config.clientId;
   logToFile(
-    `Loaded config: clientId=${maskedClientId}, cloudFunctionUrl=${config.cloudFunctionUrl}`,
+    `Loaded config: clientId=${maskedClientId}, cloudFunctionUrl=${config.cloudFunctionUrl}, profile=${config.profile || '(default)'}`,
   );
   return config;
 }


### PR DESCRIPTION
## Summary
- Adds `WORKSPACE_PROFILE` env var to isolate credentials per Google account in macOS Keychain
- No env var = default behavior (backward-compatible with upstream)
- `WORKSPACE_PROFILE=personal` → separate keychain slot `gemini-cli-workspace-oauth-personal`
- Enables running multiple MCP server instances for different Google accounts simultaneously

## Changes
- `workspace-server/src/utils/config.ts` — added `profile` field, reads `WORKSPACE_PROFILE`
- `workspace-server/src/auth/token-storage/oauth-credential-storage.ts` — keychain service name derived from profile
- `CLAUDE.md` — fork documentation with setup instructions

## Test plan
- [ ] Verify default (no profile) still authenticates as before
- [ ] Verify `WORKSPACE_PROFILE=personal` creates separate keychain entry
- [ ] Verify two Claude Code MCP instances can coexist with different accounts

🤖 Generated with [Claude Code](https://claude.com/claude-code)