### PR TITLE
feat(calendar): introduce eventType (Out of Office, Focus Time, Working Location) in Calendar Service

### DIFF
--- a/skills/google-calendar/SKILL.md
+++ b/skills/google-calendar/SKILL.md
@@ -379,13 +379,13 @@ Users may have multiple calendars (personal, work, shared team calendars).
 
 ## Tool Quick Reference
 
-| Tool                      | Action                            | Key Parameters                                                                                  |
-| :------------------------ | :-------------------------------- | :---------------------------------------------------------------------------------------------- |
-| `calendar.list`           | List all calendars                | _(none)_                                                                                        |
-| `calendar.listEvents`     | List events (filterable by type)  | `calendarId`, `timeMin`, `timeMax`, `eventTypes`                                                |
-| `calendar.getEvent`       | Get event details                 | `eventId`, `calendarId`                                                                         |
-| `calendar.createEvent`    | Create event (all types)          | `calendarId`, `summary`, `start`, `end`, `eventType`, `addGoogleMeet`, `attachments`            |
-| `calendar.updateEvent`    | Modify an existing event          | `eventId`, `summary`, `start`, `end`, `attendees`, `addGoogleMeet`, `attachments`               |
-| `calendar.deleteEvent`    | Delete an event                   | `eventId`, `calendarId`                                                                         |
-| `calendar.respondToEvent` | Accept/decline an invite          | `eventId`, `responseStatus`                                                                     |
-| `calendar.findFreeTime`   | Find available meeting time       | `attendees`, `timeMin`, `timeMax`, `duration`                                                   |
+| Tool                      | Action                           | Key Parameters                                                                       |
+| :------------------------ | :------------------------------- | :----------------------------------------------------------------------------------- |
+| `calendar.list`           | List all calendars               | _(none)_                                                                             |
+| `calendar.listEvents`     | List events (filterable by type) | `calendarId`, `timeMin`, `timeMax`, `eventTypes`                                     |
+| `calendar.getEvent`       | Get event details                | `eventId`, `calendarId`                                                              |
+| `calendar.createEvent`    | Create event (all types)         | `calendarId`, `summary`, `start`, `end`, `eventType`, `addGoogleMeet`, `attachments` |
+| `calendar.updateEvent`    | Modify an existing event         | `eventId`, `summary`, `start`, `end`, `attendees`, `addGoogleMeet`, `attachments`    |
+| `calendar.deleteEvent`    | Delete an event                  | `eventId`, `calendarId`                                                              |
+| `calendar.respondToEvent` | Accept/decline an invite         | `eventId`, `responseStatus`                                                          |
+| `calendar.findFreeTime`   | Find available meeting time      | `attendees`, `timeMin`, `timeMax`, `duration`                                        |

--- a/workspace-server/src/__tests__/services/CalendarService.test.ts
+++ b/workspace-server/src/__tests__/services/CalendarService.test.ts
@@ -1682,6 +1682,8 @@ describe('CalendarService', () => {
         eventType: 'focusTime',
       });
 
+      const insertArgs = mockCalendarAPI.events.insert.mock.calls[0][0];
+
       expect(mockCalendarAPI.events.insert).toHaveBeenCalledWith(
         expect.objectContaining({
           calendarId: 'primary-calendar-id',
@@ -1691,14 +1693,13 @@ describe('CalendarService', () => {
             end: { dateTime: '2024-01-15T12:00:00Z' },
             eventType: 'focusTime',
             transparency: 'opaque',
-            focusTimeProperties: {
-              chatStatus: 'doNotDisturb',
-              autoDeclineMode: 'declineOnlyNewConflictingInvitations',
-              declineMessage: undefined,
-            },
           }),
         }),
       );
+      expect(insertArgs.requestBody?.focusTimeProperties).toEqual({
+        chatStatus: 'doNotDisturb',
+        autoDeclineMode: 'declineOnlyNewConflictingInvitations',
+      });
 
       expect(JSON.parse(result.content[0].text)).toEqual(mockCreatedEvent);
     });
@@ -1768,6 +1769,8 @@ describe('CalendarService', () => {
         eventType: 'outOfOffice',
       });
 
+      const insertArgs = mockCalendarAPI.events.insert.mock.calls[0][0];
+
       expect(mockCalendarAPI.events.insert).toHaveBeenCalledWith(
         expect.objectContaining({
           calendarId: 'primary-calendar-id',
@@ -1777,13 +1780,12 @@ describe('CalendarService', () => {
             end: { dateTime: '2024-01-19T00:00:00Z' },
             eventType: 'outOfOffice',
             transparency: 'opaque',
-            outOfOfficeProperties: {
-              autoDeclineMode: 'declineOnlyNewConflictingInvitations',
-              declineMessage: undefined,
-            },
           }),
         }),
       );
+      expect(insertArgs.requestBody?.outOfOfficeProperties).toEqual({
+        autoDeclineMode: 'declineOnlyNewConflictingInvitations',
+      });
 
       expect(JSON.parse(result.content[0].text)).toEqual(mockCreatedEvent);
     });

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -731,9 +731,7 @@ async function main() {
               ),
             customLocation: z
               .object({
-                label: z
-                  .string()
-                  .describe('Label for the custom location.'),
+                label: z.string().describe('Label for the custom location.'),
               })
               .optional()
               .describe(
@@ -929,7 +927,6 @@ async function main() {
     },
     calendarService.deleteEvent,
   );
-
 
   server.registerTool(
     'chat.listSpaces',

--- a/workspace-server/src/services/CalendarService.ts
+++ b/workspace-server/src/services/CalendarService.ts
@@ -21,6 +21,14 @@ interface EventAttachment {
   mimeType?: string;
 }
 
+export type CalendarEventType =
+  | 'default'
+  | 'focusTime'
+  | 'outOfOffice'
+  | 'workingLocation';
+
+export type ListEventsEventType = CalendarEventType | 'birthday' | 'fromGmail';
+
 export interface CreateEventInput {
   calendarId?: string;
   summary?: string;
@@ -31,7 +39,7 @@ export interface CreateEventInput {
   sendUpdates?: 'all' | 'externalOnly' | 'none';
   addGoogleMeet?: boolean;
   attachments?: EventAttachment[];
-  eventType?: 'default' | 'focusTime' | 'outOfOffice' | 'workingLocation';
+  eventType?: CalendarEventType;
   focusTimeProperties?: {
     chatStatus?: 'available' | 'doNotDisturb';
     autoDeclineMode?:
@@ -59,7 +67,7 @@ export interface ListEventsInput {
   timeMin?: string;
   timeMax?: string;
   attendeeResponseStatus?: string[];
-  eventTypes?: string[];
+  eventTypes?: ListEventsEventType[];
 }
 
 export interface GetEventInput {
@@ -250,8 +258,7 @@ export class CalendarService {
       workingLocation: 'Working Location',
     };
     const summary =
-      input.summary ??
-      (eventType ? summaryDefaults[eventType] : undefined);
+      input.summary ?? (eventType ? summaryDefaults[eventType] : undefined);
 
     // Validate start/end: at least one of dateTime or date must be provided
     if ((!start.dateTime && !start.date) || (!end.dateTime && !end.date)) {
@@ -354,16 +361,22 @@ export class CalendarService {
           autoDeclineMode:
             focusTimeProperties?.autoDeclineMode ??
             'declineOnlyNewConflictingInvitations',
-          declineMessage: focusTimeProperties?.declineMessage,
         };
+        if (focusTimeProperties?.declineMessage !== undefined) {
+          event.focusTimeProperties.declineMessage =
+            focusTimeProperties.declineMessage;
+        }
       } else if (eventType === 'outOfOffice') {
         event.transparency = 'opaque';
         event.outOfOfficeProperties = {
           autoDeclineMode:
             outOfOfficeProperties?.autoDeclineMode ??
             'declineOnlyNewConflictingInvitations',
-          declineMessage: outOfOfficeProperties?.declineMessage,
         };
+        if (outOfOfficeProperties?.declineMessage !== undefined) {
+          event.outOfOfficeProperties.declineMessage =
+            outOfOfficeProperties.declineMessage;
+        }
       } else if (eventType === 'workingLocation') {
         // workingLocationProperties is guaranteed non-null by validation above
         const wlInput = workingLocationProperties!;
@@ -468,7 +481,8 @@ export class CalendarService {
         ?.filter(
           (event) =>
             event.status !== 'cancelled' &&
-            (!!event.summary || (event.eventType && event.eventType !== 'default')),
+            (!!event.summary ||
+              (event.eventType && event.eventType !== 'default')),
         )
         .filter((event) => {
           if (!event.attendees || event.attendees.length === 0) {
@@ -961,5 +975,4 @@ export class CalendarService {
       };
     }
   };
-
 }


### PR DESCRIPTION
Implements Google Calendar Status Events by adding three new MCP tools - `calendar.createFocusTime`, `calendar.createOutOfOffice`, and `calendar.setWorkingLocation` - that allow users to create status events with their respective properties such as auto-decline mode, decline messages, chat status, and working location details. The `calendar.listEvents` tool is extended with an eventTypes filter parameter so users can query specific event types like `focusTime`, `outOfOffice`, `workingLocation`, birthday, or fromGmail, and its response fields now include eventType, focusTimeProperties, outOfOfficeProperties, and workingLocationProperties. This change also fixes an issue where status events without a summary were silently dropped from list results, since these event types may not always have a summary set.