### PR TITLE
fix: handle npm.cmd on Windows in runCommand

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -9,6 +9,11 @@ const path = require('node:path');
 
 function runCommand(command, args, options) {
   return new Promise((resolve, reject) => {
+    // On Windows, npm is a batch file and needs a shell
+    if (process.platform === 'win32' && command === 'npm') {
+      command = `${command}.cmd`;
+      options = { ...options, shell: true };
+    }
     const child = spawn(command, args, options);
 
     // Pipe stderr to the parent process's stderr if it's available.


### PR DESCRIPTION
Fixes #299. Using the same pattern as in https://github.com/google-gemini/gemini-cli/blame/104587bae8326e7ad1e2d739b7e14c7665e10b2b/scripts/build_binary.js#L45-L51