### PR TITLE
chore: split typescript into its own dependabot group

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,11 +30,6 @@ updates:
       npm-workspace-server:
         patterns:
           - '*'
-        exclude-patterns:
-          - 'typescript'
-      typescript:
-        patterns:
-          - 'typescript'
     labels:
       - 'dependencies'
       - 'npm'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,14 +6,12 @@ updates:
       interval: 'weekly'
     open-pull-requests-limit: 5
     groups:
-      npm-root:
-        patterns:
-          - '*'
-        exclude-patterns:
-          - 'typescript'
       typescript:
         patterns:
           - 'typescript'
+      npm-root:
+        patterns:
+          - '*'
     labels:
       - 'dependencies'
       - 'npm'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,11 @@ updates:
       npm-root:
         patterns:
           - '*'
+        exclude-patterns:
+          - 'typescript'
+      typescript:
+        patterns:
+          - 'typescript'
     labels:
       - 'dependencies'
       - 'npm'
@@ -25,6 +30,11 @@ updates:
       npm-workspace-server:
         patterns:
           - '*'
+        exclude-patterns:
+          - 'typescript'
+      typescript:
+        patterns:
+          - 'typescript'
     labels:
       - 'dependencies'
       - 'npm'


### PR DESCRIPTION
## Summary

- Splits `typescript` into its own dependabot group for both npm ecosystems (root and workspace-server)
- Prevents TypeScript major version bumps from blocking unrelated dependency updates

This was prompted by #293 where TypeScript 6.0.2 had a peer dependency conflict with `@typescript-eslint/eslint-plugin` (which requires `typescript <6.0.0`), causing the entire grouped PR to fail CI.

## Test plan

- [x] Verify next dependabot run creates separate PRs for TypeScript vs other npm deps