### PR TITLE
fix: error running `npm run clean` on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "test:ci": "npm run test:ci --workspaces --if-present",
     "start": "npm run start --workspaces --if-present",
     "auth-utils": "npm run build:auth-utils -w workspace-server && node scripts/auth-utils.js",
-    "clean": "npm run clean --workspaces --if-present && rm -rf release node_modules logs docs/.vitepress/cache docs/.vitepress/dist",
+    "clean": "node scripts/clean.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format:check": "prettier --check .",

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -1,0 +1,31 @@
+/**
+ * @license
+ * Copyright 2026 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+const { rmSync, readFileSync } = require('node:fs');
+const { join } = require('node:path');
+
+const root = join(__dirname, '..');
+const RMRF = { recursive: true, force: true };
+
+function rmrfSyncVerbose(path) {
+  console.log(`Removing ${path}`);
+  rmSync(path, RMRF);
+}
+
+// Clean up all workspaces.
+const { workspaces } = JSON.parse(
+  readFileSync(join(root, 'package.json'), 'utf-8'),
+);
+for (const workspace of workspaces) {
+  rmrfSyncVerbose(join(root, workspace, 'dist'));
+}
+
+// Root artifacts.
+rmrfSyncVerbose(join(root, 'node_modules'));
+rmrfSyncVerbose(join(root, 'release'));
+rmrfSyncVerbose(join(root, 'logs'));
+rmrfSyncVerbose(join(root, 'docs', '.vitepress', 'cache'));
+rmrfSyncVerbose(join(root, 'docs', '.vitepress', 'dist'));

--- a/workspace-server/package.json
+++ b/workspace-server/package.json
@@ -9,7 +9,6 @@
     "test:coverage": "cd .. && node --max-old-space-size=4096 node_modules/jest/bin/jest.js --coverage",
     "test:ci": "cd .. && node --max-old-space-size=4096 node_modules/jest/bin/jest.js --ci --coverage --maxWorkers=2",
     "start": "ts-node src/index.ts",
-    "clean": "rm -rf dist node_modules",
     "build": "node esbuild.config.js && node esbuild.headless-login.js",
     "build:auth-utils": "node esbuild.auth-utils.js",
     "build:headless-login": "node esbuild.headless-login.js"


### PR DESCRIPTION
The issue was with `rm` missing on Windows. I've reused same `npm run clean` approach as used in gemini-cli (https://github.com/google-gemini/gemini-cli/blob/main/scripts/clean.js), alternatively we could have used https://www.npmjs.com/package/rimraf, but i'm not sure how keen the repo would be about adding a new dependency 😅