### PR TITLE
docs: use `npm run auth-utils -- login` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ If you're using the extension over SSH, WSL, Cloud Shell, or another environment
 without a local browser, you can authenticate using the headless login tool:
 
 ```bash
-node scripts/auth-utils.js login
+npm run auth-utils -- login
 ```
 
 This prints an OAuth URL you can open in any browser (local machine, phone,

--- a/docs/development.md
+++ b/docs/development.md
@@ -172,7 +172,7 @@ authentication credentials.
 To use the script, run the following command:
 
 ```bash
-node scripts/auth-utils.js <command>
+npm run auth-utils -- <command>
 ```
 
 ### Commands
@@ -191,7 +191,7 @@ Cloud Shell, VMs), authentication requires manual steps:
 
 1. Run the login tool:
    ```bash
-   node scripts/auth-utils.js login
+   npm run auth-utils -- login
    ```
    Or, from the `workspace-server` directory:
    ```bash

--- a/scripts/auth-utils.js
+++ b/scripts/auth-utils.js
@@ -90,7 +90,7 @@ function showHelp() {
   console.log(`
 Auth Management CLI
 
-Usage: node scripts/auth-utils.js <command>
+Usage: npm run auth-utils -- <command>
 
 Commands:
   login     Authenticate via headless OAuth flow (for SSH/WSL/Cloud Shell)
@@ -100,10 +100,10 @@ Commands:
   help      Show this help message
 
 Examples:
-  node scripts/auth-utils.js login
-  node scripts/auth-utils.js clear
-  node scripts/auth-utils.js expire
-  node scripts/auth-utils.js status
+  npm run auth-utils -- login
+  npm run auth-utils -- clear
+  npm run auth-utils -- expire
+  npm run auth-utils -- status
 `);
 }
 


### PR DESCRIPTION
More idiomatic than calling the script directly, since we already have `auth-utils` script in `npm run`.