### PR TITLE
feat(tasks): add support for Google Tasks

### DIFF
--- a/workspace-server/WORKSPACE-Context.md
+++ b/workspace-server/WORKSPACE-Context.md
@@ -200,6 +200,19 @@ filter rather than searching by name alone. Example MIME type queries:
 - See the **Google Chat skill** for detailed guidance on formatting messages,
   spaces vs. DMs, threading, unread filtering, and space management.
 
+### Google Tasks
+
+- **Task List Selection**: If the user doesn't specify a task list, default to
+  listing all task lists first to let them choose, or ask for clarification.
+- **Task Creation**: When creating tasks, prompt for a due date if one isn't
+  provided, as it's helpful for organization.
+- **Completion**: Use `tasks.complete` for a simple "mark as done" action. Use
+  `tasks.update` if you need to set other properties simultaneously.
+- **Assigned Tasks**: To find tasks assigned from Google Docs or Chat, use
+  `showAssigned=true` when listing tasks.
+- **Timestamps**: Ensure due dates are in RFC 3339 format (e.g.,
+  `2024-01-15T12:00:00Z`).
+
 Remember: This guide focuses on **how to think** about using these tools
 effectively. For specific parameter details, refer to the tool descriptions
 themselves.

--- a/workspace-server/src/__tests__/services/TasksService.test.ts
+++ b/workspace-server/src/__tests__/services/TasksService.test.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/workspace-server/src/__tests__/services/TasksService.test.ts
+++ b/workspace-server/src/__tests__/services/TasksService.test.ts
@@ -67,10 +67,7 @@ describe('TasksService', () => {
 
       const result = await tasksService.listTaskLists();
 
-      expect(mockTasksAPI.tasklists.list).toHaveBeenCalledWith({
-        maxResults: undefined,
-        pageToken: undefined,
-      });
+      expect(mockTasksAPI.tasklists.list).toHaveBeenCalledWith({});
       expect(JSON.parse(result.content[0].text)).toEqual({ items: mockItems });
     });
 
@@ -124,14 +121,7 @@ describe('TasksService', () => {
 
       expect(mockTasksAPI.tasks.list).toHaveBeenCalledWith({
         tasklist: 'list1',
-        showCompleted: undefined,
-        showDeleted: undefined,
-        showHidden: undefined,
         showAssigned: true,
-        maxResults: undefined,
-        pageToken: undefined,
-        dueMin: undefined,
-        dueMax: undefined,
       });
       expect(JSON.parse(result.content[0].text)).toEqual({ items: mockItems });
     });

--- a/workspace-server/src/__tests__/services/TasksService.test.ts
+++ b/workspace-server/src/__tests__/services/TasksService.test.ts
@@ -71,7 +71,7 @@ describe('TasksService', () => {
         maxResults: undefined,
         pageToken: undefined,
       });
-      expect(JSON.parse(result.content[0].text)).toEqual(mockItems);
+      expect(JSON.parse(result.content[0].text)).toEqual({ items: mockItems });
     });
 
     it('should pass pagination parameters', async () => {
@@ -94,7 +94,7 @@ describe('TasksService', () => {
 
       const result = await tasksService.listTaskLists();
 
-      expect(JSON.parse(result.content[0].text)).toEqual([]);
+      expect(JSON.parse(result.content[0].text)).toEqual({});
     });
 
     it('should handle API errors gracefully', async () => {
@@ -133,7 +133,7 @@ describe('TasksService', () => {
         dueMin: undefined,
         dueMax: undefined,
       });
-      expect(JSON.parse(result.content[0].text)).toEqual(mockItems);
+      expect(JSON.parse(result.content[0].text)).toEqual({ items: mockItems });
     });
 
     it('should handle API errors gracefully', async () => {
@@ -291,9 +291,9 @@ describe('TasksService', () => {
         tasklist: 'list1',
         task: 'task1',
       });
-      expect(result.content[0].text).toBe(
-        'Task task1 deleted successfully from list list1.',
-      );
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        message: 'Task task1 deleted successfully from list list1.',
+      });
     });
 
     it('should handle API errors gracefully', async () => {

--- a/workspace-server/src/__tests__/services/TasksService.test.ts
+++ b/workspace-server/src/__tests__/services/TasksService.test.ts
@@ -1,0 +1,314 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  describe,
+  it,
+  expect,
+  jest,
+  beforeEach,
+  afterEach,
+} from '@jest/globals';
+import { TasksService } from '../../services/TasksService';
+import { AuthManager } from '../../auth/AuthManager';
+import { google } from 'googleapis';
+
+// Mock the googleapis module
+jest.mock('googleapis');
+jest.mock('../../utils/logger');
+
+describe('TasksService', () => {
+  let tasksService: TasksService;
+  let mockAuthManager: jest.Mocked<AuthManager>;
+  let mockTasksAPI: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockAuthManager = {
+      getAuthenticatedClient: jest.fn(),
+    } as any;
+
+    mockTasksAPI = {
+      tasklists: {
+        list: jest.fn(),
+      },
+      tasks: {
+        list: jest.fn(),
+        insert: jest.fn(),
+        patch: jest.fn(),
+        delete: jest.fn(),
+      },
+    };
+
+    (google.tasks as jest.Mock) = jest.fn().mockReturnValue(mockTasksAPI);
+
+    tasksService = new TasksService(mockAuthManager);
+
+    const mockAuthClient = { access_token: 'test-token' };
+    mockAuthManager.getAuthenticatedClient.mockResolvedValue(
+      mockAuthClient as any,
+    );
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('listTaskLists', () => {
+    it('should list task lists', async () => {
+      const mockItems = [{ id: 'list1', title: 'My Tasks' }];
+      mockTasksAPI.tasklists.list.mockResolvedValue({
+        data: { items: mockItems },
+      });
+
+      const result = await tasksService.listTaskLists();
+
+      expect(mockTasksAPI.tasklists.list).toHaveBeenCalledWith({
+        maxResults: undefined,
+        pageToken: undefined,
+      });
+      expect(JSON.parse(result.content[0].text)).toEqual(mockItems);
+    });
+
+    it('should pass pagination parameters', async () => {
+      mockTasksAPI.tasklists.list.mockResolvedValue({
+        data: { items: [] },
+      });
+
+      await tasksService.listTaskLists({ maxResults: 10, pageToken: 'token' });
+
+      expect(mockTasksAPI.tasklists.list).toHaveBeenCalledWith({
+        maxResults: 10,
+        pageToken: 'token',
+      });
+    });
+
+    it('should return empty array when no items', async () => {
+      mockTasksAPI.tasklists.list.mockResolvedValue({
+        data: {},
+      });
+
+      const result = await tasksService.listTaskLists();
+
+      expect(JSON.parse(result.content[0].text)).toEqual([]);
+    });
+
+    it('should handle API errors gracefully', async () => {
+      mockTasksAPI.tasklists.list.mockRejectedValue(
+        new Error('Tasks API failed'),
+      );
+
+      const result = await tasksService.listTaskLists();
+
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        error: 'Tasks API failed',
+      });
+    });
+  });
+
+  describe('listTasks', () => {
+    it('should list tasks in a task list', async () => {
+      const mockItems = [{ id: 'task1', title: 'Buy milk' }];
+      mockTasksAPI.tasks.list.mockResolvedValue({
+        data: { items: mockItems },
+      });
+
+      const result = await tasksService.listTasks({
+        taskListId: 'list1',
+        showAssigned: true,
+      });
+
+      expect(mockTasksAPI.tasks.list).toHaveBeenCalledWith({
+        tasklist: 'list1',
+        showCompleted: undefined,
+        showDeleted: undefined,
+        showHidden: undefined,
+        showAssigned: true,
+        maxResults: undefined,
+        pageToken: undefined,
+        dueMin: undefined,
+        dueMax: undefined,
+      });
+      expect(JSON.parse(result.content[0].text)).toEqual(mockItems);
+    });
+
+    it('should handle API errors gracefully', async () => {
+      mockTasksAPI.tasks.list.mockRejectedValue(new Error('Tasks API failed'));
+
+      const result = await tasksService.listTasks({ taskListId: 'list1' });
+
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        error: 'Tasks API failed',
+      });
+    });
+  });
+
+  describe('createTask', () => {
+    it('should create a task with title only', async () => {
+      const mockResponse = { id: 'task1', title: 'New Task' };
+      mockTasksAPI.tasks.insert.mockResolvedValue({
+        data: mockResponse,
+      });
+
+      const result = await tasksService.createTask({
+        taskListId: 'list1',
+        title: 'New Task',
+      });
+
+      expect(mockTasksAPI.tasks.insert).toHaveBeenCalledWith({
+        tasklist: 'list1',
+        requestBody: {
+          title: 'New Task',
+        },
+      });
+      expect(JSON.parse(result.content[0].text)).toEqual(mockResponse);
+    });
+
+    it('should create a task with notes and due date', async () => {
+      const mockResponse = {
+        id: 'task1',
+        title: 'New Task',
+        notes: 'Some notes',
+        due: '2024-01-15T12:00:00Z',
+      };
+      mockTasksAPI.tasks.insert.mockResolvedValue({
+        data: mockResponse,
+      });
+
+      const result = await tasksService.createTask({
+        taskListId: 'list1',
+        title: 'New Task',
+        notes: 'Some notes',
+        due: '2024-01-15T12:00:00Z',
+      });
+
+      expect(mockTasksAPI.tasks.insert).toHaveBeenCalledWith({
+        tasklist: 'list1',
+        requestBody: {
+          title: 'New Task',
+          notes: 'Some notes',
+          due: '2024-01-15T12:00:00Z',
+        },
+      });
+      expect(JSON.parse(result.content[0].text)).toEqual(mockResponse);
+    });
+
+    it('should handle API errors gracefully', async () => {
+      mockTasksAPI.tasks.insert.mockRejectedValue(
+        new Error('Tasks API failed'),
+      );
+
+      const result = await tasksService.createTask({
+        taskListId: 'list1',
+        title: 'New Task',
+      });
+
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        error: 'Tasks API failed',
+      });
+    });
+  });
+
+  describe('updateTask', () => {
+    it('should update a task', async () => {
+      const mockResponse = { id: 'task1', title: 'Updated Task' };
+      mockTasksAPI.tasks.patch.mockResolvedValue({
+        data: mockResponse,
+      });
+
+      const result = await tasksService.updateTask({
+        taskListId: 'list1',
+        taskId: 'task1',
+        title: 'Updated Task',
+      });
+
+      expect(mockTasksAPI.tasks.patch).toHaveBeenCalledWith({
+        tasklist: 'list1',
+        task: 'task1',
+        requestBody: {
+          title: 'Updated Task',
+        },
+      });
+      expect(JSON.parse(result.content[0].text)).toEqual(mockResponse);
+    });
+
+    it('should handle API errors gracefully', async () => {
+      mockTasksAPI.tasks.patch.mockRejectedValue(new Error('Tasks API failed'));
+
+      const result = await tasksService.updateTask({
+        taskListId: 'list1',
+        taskId: 'task1',
+        title: 'Updated Task',
+      });
+
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        error: 'Tasks API failed',
+      });
+    });
+  });
+
+  describe('completeTask', () => {
+    it('should mark a task as completed', async () => {
+      const mockResponse = {
+        id: 'task1',
+        title: 'Task 1',
+        status: 'completed',
+      };
+      mockTasksAPI.tasks.patch.mockResolvedValue({
+        data: mockResponse,
+      });
+
+      const result = await tasksService.completeTask({
+        taskListId: 'list1',
+        taskId: 'task1',
+      });
+
+      expect(mockTasksAPI.tasks.patch).toHaveBeenCalledWith({
+        tasklist: 'list1',
+        task: 'task1',
+        requestBody: {
+          status: 'completed',
+        },
+      });
+      expect(JSON.parse(result.content[0].text)).toEqual(mockResponse);
+    });
+  });
+
+  describe('deleteTask', () => {
+    it('should delete a task', async () => {
+      mockTasksAPI.tasks.delete.mockResolvedValue({});
+
+      const result = await tasksService.deleteTask({
+        taskListId: 'list1',
+        taskId: 'task1',
+      });
+
+      expect(mockTasksAPI.tasks.delete).toHaveBeenCalledWith({
+        tasklist: 'list1',
+        task: 'task1',
+      });
+      expect(result.content[0].text).toBe(
+        'Task task1 deleted successfully from list list1.',
+      );
+    });
+
+    it('should handle API errors gracefully', async () => {
+      mockTasksAPI.tasks.delete.mockRejectedValue(
+        new Error('Tasks API failed'),
+      );
+
+      const result = await tasksService.deleteTask({
+        taskListId: 'list1',
+        taskId: 'task1',
+      });
+
+      expect(JSON.parse(result.content[0].text)).toEqual({
+        error: 'Tasks API failed',
+      });
+    });
+  });
+});

--- a/workspace-server/src/features/feature-config.ts
+++ b/workspace-server/src/features/feature-config.ts
@@ -260,14 +260,14 @@ export const FEATURE_GROUPS: readonly FeatureGroup[] = [
     service: 'tasks',
     group: 'read',
     scopes: scopes('tasks.readonly'),
-    tools: [],
+    tools: ['tasks.listLists', 'tasks.list'],
     defaultEnabled: false,
   },
   {
     service: 'tasks',
     group: 'write',
     scopes: scopes('tasks'),
-    tools: [],
+    tools: ['tasks.create', 'tasks.update', 'tasks.complete', 'tasks.delete'],
     defaultEnabled: false,
   },
 ] as const satisfies readonly FeatureGroup[];

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -19,6 +19,7 @@ import { TimeService } from './services/TimeService';
 import { PeopleService } from './services/PeopleService';
 import { SlidesService } from './services/SlidesService';
 import { SheetsService } from './services/SheetsService';
+import { TasksService } from './services/TasksService';
 import { GMAIL_SEARCH_MAX_RESULTS } from './utils/constants';
 
 import { setLoggingEnabled } from './utils/logger';
@@ -128,6 +129,7 @@ async function main() {
   const timeService = new TimeService();
   const slidesService = new SlidesService(authManager);
   const sheetsService = new SheetsService(authManager);
+  const tasksService = new TasksService(authManager);
 
   // 3. Register tools directly on the server
   // Handle tool name normalization (dots to underscores) by default, or use dots if --use-dot-names is passed.
@@ -1313,6 +1315,137 @@ System labels that can be modified:
       ...readOnlyToolProps,
     },
     peopleService.getUserRelations,
+  );
+
+  // Tasks tools
+  server.registerTool(
+    'tasks.listLists',
+    {
+      description: "Lists the authenticated user's task lists.",
+      inputSchema: {
+        maxResults: z
+          .number()
+          .optional()
+          .describe('Maximum number of task lists to return.'),
+        pageToken: z
+          .string()
+          .optional()
+          .describe('Token for the next page of results.'),
+      },
+      ...readOnlyToolProps,
+    },
+    tasksService.listTaskLists,
+  );
+
+  server.registerTool(
+    'tasks.list',
+    {
+      description: 'Lists tasks in a specific task list.',
+      inputSchema: {
+        taskListId: z.string().describe('The ID of the task list.'),
+        showCompleted: z
+          .boolean()
+          .optional()
+          .describe('Whether to show completed tasks.'),
+        showDeleted: z
+          .boolean()
+          .optional()
+          .describe('Whether to show deleted tasks.'),
+        showHidden: z
+          .boolean()
+          .optional()
+          .describe('Whether to show hidden tasks.'),
+        showAssigned: z
+          .boolean()
+          .optional()
+          .describe('Whether to show tasks assigned from Docs or Chat.'),
+        maxResults: z
+          .number()
+          .optional()
+          .describe('Maximum number of tasks to return.'),
+        pageToken: z
+          .string()
+          .optional()
+          .describe('Token for the next page of results.'),
+        dueMin: z
+          .string()
+          .optional()
+          .describe(
+            "Lower bound for a task's due date (as a RFC 3339 timestamp).",
+          ),
+        dueMax: z
+          .string()
+          .optional()
+          .describe(
+            "Upper bound for a task's due date (as a RFC 3339 timestamp).",
+          ),
+      },
+      ...readOnlyToolProps,
+    },
+    tasksService.listTasks,
+  );
+
+  server.registerTool(
+    'tasks.create',
+    {
+      description: 'Creates a new task in the specified task list.',
+      inputSchema: {
+        taskListId: z.string().describe('The ID of the task list.'),
+        title: z.string().describe('The title of the task.'),
+        notes: z.string().optional().describe('Notes for the task.'),
+        due: z
+          .string()
+          .optional()
+          .describe('The due date for the task (as a RFC 3339 timestamp).'),
+      },
+    },
+    tasksService.createTask,
+  );
+
+  server.registerTool(
+    'tasks.update',
+    {
+      description: 'Updates an existing task.',
+      inputSchema: {
+        taskListId: z.string().describe('The ID of the task list.'),
+        taskId: z.string().describe('The ID of the task to update.'),
+        title: z.string().optional().describe('The new title of the task.'),
+        notes: z.string().optional().describe('The new notes for the task.'),
+        status: z
+          .enum(['needsAction', 'completed'])
+          .optional()
+          .describe('The new status of the task.'),
+        due: z
+          .string()
+          .optional()
+          .describe('The new due date for the task (as a RFC 3339 timestamp).'),
+      },
+    },
+    tasksService.updateTask,
+  );
+
+  server.registerTool(
+    'tasks.complete',
+    {
+      description: 'Completes a task (convenience wrapper around update).',
+      inputSchema: {
+        taskListId: z.string().describe('The ID of the task list.'),
+        taskId: z.string().describe('The ID of the task to complete.'),
+      },
+    },
+    tasksService.completeTask,
+  );
+
+  server.registerTool(
+    'tasks.delete',
+    {
+      description: 'Deletes a task.',
+      inputSchema: {
+        taskListId: z.string().describe('The ID of the task list.'),
+        taskId: z.string().describe('The ID of the task to delete.'),
+      },
+    },
+    tasksService.deleteTask,
   );
 
   // 4. Connect the transport layer and start listening

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -1909,13 +1909,13 @@ System labels that can be modified:
           .string()
           .optional()
           .describe(
-            "Lower bound for a task's due date (as a RFC 3339 timestamp).",
+            'Lower bound for a task\'s due date (as a RFC 3339 timestamp, e.g., "2024-01-15T12:00:00Z").',
           ),
         dueMax: z
           .string()
           .optional()
           .describe(
-            "Upper bound for a task's due date (as a RFC 3339 timestamp).",
+            'Upper bound for a task\'s due date (as a RFC 3339 timestamp, e.g., "2024-01-15T12:00:00Z").',
           ),
       },
       ...readOnlyToolProps,
@@ -1934,7 +1934,9 @@ System labels that can be modified:
         due: z
           .string()
           .optional()
-          .describe('The due date for the task (as a RFC 3339 timestamp).'),
+          .describe(
+            'The due date for the task (as a RFC 3339 timestamp, e.g., "2024-01-15T12:00:00Z").',
+          ),
       },
     },
     tasksService.createTask,
@@ -1956,7 +1958,9 @@ System labels that can be modified:
         due: z
           .string()
           .optional()
-          .describe('The new due date for the task (as a RFC 3339 timestamp).'),
+          .describe(
+            'The new due date for the task (as a RFC 3339 timestamp, e.g., "2024-01-15T12:00:00Z").',
+          ),
       },
     },
     tasksService.updateTask,

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -1855,8 +1855,8 @@ System labels that can be modified:
     peopleService.getUserRelations,
   );
 
-  // Tasks tools
-  server.registerTool(
+  // Tasks tools (gated behind the tasks feature groups; default-OFF)
+  registerTool(
     'tasks.listLists',
     {
       description: "Lists the authenticated user's task lists.",
@@ -1875,7 +1875,7 @@ System labels that can be modified:
     tasksService.listTaskLists,
   );
 
-  server.registerTool(
+  registerTool(
     'tasks.list',
     {
       description: 'Lists tasks in a specific task list.',
@@ -1923,7 +1923,7 @@ System labels that can be modified:
     tasksService.listTasks,
   );
 
-  server.registerTool(
+  registerTool(
     'tasks.create',
     {
       description: 'Creates a new task in the specified task list.',
@@ -1940,7 +1940,7 @@ System labels that can be modified:
     tasksService.createTask,
   );
 
-  server.registerTool(
+  registerTool(
     'tasks.update',
     {
       description: 'Updates an existing task.',
@@ -1962,7 +1962,7 @@ System labels that can be modified:
     tasksService.updateTask,
   );
 
-  server.registerTool(
+  registerTool(
     'tasks.complete',
     {
       description: 'Completes a task (convenience wrapper around update).',
@@ -1974,7 +1974,7 @@ System labels that can be modified:
     tasksService.completeTask,
   );
 
-  server.registerTool(
+  registerTool(
     'tasks.delete',
     {
       description: 'Deletes a task.',

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -19,6 +19,7 @@ import { TimeService } from './services/TimeService';
 import { PeopleService } from './services/PeopleService';
 import { SlidesService, PREDEFINED_LAYOUTS } from './services/SlidesService';
 import { SheetsService } from './services/SheetsService';
+import { TasksService } from './services/TasksService';
 import { GMAIL_SEARCH_MAX_RESULTS } from './utils/constants';
 
 import { setLoggingEnabled, logToFile } from './utils/logger';
@@ -195,6 +196,7 @@ async function main() {
   const timeService = new TimeService();
   const slidesService = new SlidesService(authManager);
   const sheetsService = new SheetsService(authManager);
+  const tasksService = new TasksService(authManager);
 
   // 3. Register tools directly on the server
   // Handle tool name normalization (dots to underscores) by default, or use dots if --use-dot-names is passed.
@@ -1851,6 +1853,137 @@ System labels that can be modified:
       ...readOnlyToolProps,
     },
     peopleService.getUserRelations,
+  );
+
+  // Tasks tools
+  server.registerTool(
+    'tasks.listLists',
+    {
+      description: "Lists the authenticated user's task lists.",
+      inputSchema: {
+        maxResults: z
+          .number()
+          .optional()
+          .describe('Maximum number of task lists to return.'),
+        pageToken: z
+          .string()
+          .optional()
+          .describe('Token for the next page of results.'),
+      },
+      ...readOnlyToolProps,
+    },
+    tasksService.listTaskLists,
+  );
+
+  server.registerTool(
+    'tasks.list',
+    {
+      description: 'Lists tasks in a specific task list.',
+      inputSchema: {
+        taskListId: z.string().describe('The ID of the task list.'),
+        showCompleted: z
+          .boolean()
+          .optional()
+          .describe('Whether to show completed tasks.'),
+        showDeleted: z
+          .boolean()
+          .optional()
+          .describe('Whether to show deleted tasks.'),
+        showHidden: z
+          .boolean()
+          .optional()
+          .describe('Whether to show hidden tasks.'),
+        showAssigned: z
+          .boolean()
+          .optional()
+          .describe('Whether to show tasks assigned from Docs or Chat.'),
+        maxResults: z
+          .number()
+          .optional()
+          .describe('Maximum number of tasks to return.'),
+        pageToken: z
+          .string()
+          .optional()
+          .describe('Token for the next page of results.'),
+        dueMin: z
+          .string()
+          .optional()
+          .describe(
+            "Lower bound for a task's due date (as a RFC 3339 timestamp).",
+          ),
+        dueMax: z
+          .string()
+          .optional()
+          .describe(
+            "Upper bound for a task's due date (as a RFC 3339 timestamp).",
+          ),
+      },
+      ...readOnlyToolProps,
+    },
+    tasksService.listTasks,
+  );
+
+  server.registerTool(
+    'tasks.create',
+    {
+      description: 'Creates a new task in the specified task list.',
+      inputSchema: {
+        taskListId: z.string().describe('The ID of the task list.'),
+        title: z.string().describe('The title of the task.'),
+        notes: z.string().optional().describe('Notes for the task.'),
+        due: z
+          .string()
+          .optional()
+          .describe('The due date for the task (as a RFC 3339 timestamp).'),
+      },
+    },
+    tasksService.createTask,
+  );
+
+  server.registerTool(
+    'tasks.update',
+    {
+      description: 'Updates an existing task.',
+      inputSchema: {
+        taskListId: z.string().describe('The ID of the task list.'),
+        taskId: z.string().describe('The ID of the task to update.'),
+        title: z.string().optional().describe('The new title of the task.'),
+        notes: z.string().optional().describe('The new notes for the task.'),
+        status: z
+          .enum(['needsAction', 'completed'])
+          .optional()
+          .describe('The new status of the task.'),
+        due: z
+          .string()
+          .optional()
+          .describe('The new due date for the task (as a RFC 3339 timestamp).'),
+      },
+    },
+    tasksService.updateTask,
+  );
+
+  server.registerTool(
+    'tasks.complete',
+    {
+      description: 'Completes a task (convenience wrapper around update).',
+      inputSchema: {
+        taskListId: z.string().describe('The ID of the task list.'),
+        taskId: z.string().describe('The ID of the task to complete.'),
+      },
+    },
+    tasksService.completeTask,
+  );
+
+  server.registerTool(
+    'tasks.delete',
+    {
+      description: 'Deletes a task.',
+      inputSchema: {
+        taskListId: z.string().describe('The ID of the task list.'),
+        taskId: z.string().describe('The ID of the task to delete.'),
+      },
+    },
+    tasksService.deleteTask,
   );
 
   // 4. Connect the transport layer and start listening

--- a/workspace-server/src/services/TasksService.ts
+++ b/workspace-server/src/services/TasksService.ts
@@ -1,6 +1,6 @@
 /**
  * @license
- * Copyright 2025 Google LLC
+ * Copyright 2026 Google LLC
  * SPDX-License-Identifier: Apache-2.0
  */
 

--- a/workspace-server/src/services/TasksService.ts
+++ b/workspace-server/src/services/TasksService.ts
@@ -36,7 +36,7 @@ export class TasksService {
         content: [
           {
             type: 'text' as const,
-            text: JSON.stringify(response.data.items || []),
+            text: JSON.stringify(response.data),
           },
         ],
       };
@@ -88,7 +88,7 @@ export class TasksService {
         content: [
           {
             type: 'text' as const,
-            text: JSON.stringify(response.data.items || []),
+            text: JSON.stringify(response.data),
           },
         ],
       };
@@ -233,7 +233,9 @@ export class TasksService {
         content: [
           {
             type: 'text' as const,
-            text: `Task ${params.taskId} deleted successfully from list ${params.taskListId}.`,
+            text: JSON.stringify({
+              message: `Task ${params.taskId} deleted successfully from list ${params.taskListId}.`,
+            }),
           },
         ],
       };

--- a/workspace-server/src/services/TasksService.ts
+++ b/workspace-server/src/services/TasksService.ts
@@ -28,8 +28,12 @@ export class TasksService {
     try {
       const tasks = await this.getTasksClient();
       const response = await tasks.tasklists.list({
-        maxResults: params.maxResults,
-        pageToken: params.pageToken,
+        ...(params.maxResults !== undefined && {
+          maxResults: params.maxResults,
+        }),
+        ...(params.pageToken !== undefined && {
+          pageToken: params.pageToken,
+        }),
       });
 
       return {
@@ -74,14 +78,26 @@ export class TasksService {
       const tasks = await this.getTasksClient();
       const response = await tasks.tasks.list({
         tasklist: params.taskListId,
-        showCompleted: params.showCompleted,
-        showDeleted: params.showDeleted,
-        showHidden: params.showHidden,
-        showAssigned: params.showAssigned,
-        maxResults: params.maxResults,
-        pageToken: params.pageToken,
-        dueMin: params.dueMin,
-        dueMax: params.dueMax,
+        ...(params.showCompleted !== undefined && {
+          showCompleted: params.showCompleted,
+        }),
+        ...(params.showDeleted !== undefined && {
+          showDeleted: params.showDeleted,
+        }),
+        ...(params.showHidden !== undefined && {
+          showHidden: params.showHidden,
+        }),
+        ...(params.showAssigned !== undefined && {
+          showAssigned: params.showAssigned,
+        }),
+        ...(params.maxResults !== undefined && {
+          maxResults: params.maxResults,
+        }),
+        ...(params.pageToken !== undefined && {
+          pageToken: params.pageToken,
+        }),
+        ...(params.dueMin !== undefined && { dueMin: params.dueMin }),
+        ...(params.dueMax !== undefined && { dueMax: params.dueMax }),
       });
 
       return {

--- a/workspace-server/src/services/TasksService.ts
+++ b/workspace-server/src/services/TasksService.ts
@@ -1,0 +1,254 @@
+/**
+ * @license
+ * Copyright 2025 Google LLC
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import { tasks_v1, google } from 'googleapis';
+import { AuthManager } from '../auth/AuthManager';
+import { logToFile } from '../utils/logger';
+import { gaxiosOptions } from '../utils/GaxiosConfig';
+
+export class TasksService {
+  constructor(private authManager: AuthManager) {}
+
+  private async getTasksClient(): Promise<tasks_v1.Tasks> {
+    const auth = await this.authManager.getAuthenticatedClient();
+    const options = { ...gaxiosOptions, auth };
+    return google.tasks({ version: 'v1', ...options });
+  }
+
+  /**
+   * Lists the authenticated user's task lists.
+   */
+  listTaskLists = async (
+    params: { maxResults?: number; pageToken?: string } = {},
+  ) => {
+    logToFile('Listing task lists');
+    try {
+      const tasks = await this.getTasksClient();
+      const response = await tasks.tasklists.list({
+        maxResults: params.maxResults,
+        pageToken: params.pageToken,
+      });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(response.data.items || []),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logToFile(`Error during tasks.listLists: ${errorMessage}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ error: errorMessage }),
+          },
+        ],
+      };
+    }
+  };
+
+  /**
+   * Lists tasks in a specific task list.
+   */
+  listTasks = async (params: {
+    taskListId: string;
+    showCompleted?: boolean;
+    showDeleted?: boolean;
+    showHidden?: boolean;
+    showAssigned?: boolean;
+    maxResults?: number;
+    pageToken?: string;
+    dueMin?: string;
+    dueMax?: string;
+  }) => {
+    logToFile(`Listing tasks in list: ${params.taskListId}`);
+    try {
+      const tasks = await this.getTasksClient();
+      const response = await tasks.tasks.list({
+        tasklist: params.taskListId,
+        showCompleted: params.showCompleted,
+        showDeleted: params.showDeleted,
+        showHidden: params.showHidden,
+        showAssigned: params.showAssigned,
+        maxResults: params.maxResults,
+        pageToken: params.pageToken,
+        dueMin: params.dueMin,
+        dueMax: params.dueMax,
+      });
+
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(response.data.items || []),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logToFile(`Error during tasks.list: ${errorMessage}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ error: errorMessage }),
+          },
+        ],
+      };
+    }
+  };
+
+  /**
+   * Creates a new task in the specified task list.
+   */
+  createTask = async (params: {
+    taskListId: string;
+    title: string;
+    notes?: string;
+    due?: string;
+  }) => {
+    logToFile(`Creating task in list: ${params.taskListId}`);
+    try {
+      const tasks = await this.getTasksClient();
+      const requestBody: tasks_v1.Schema$Task = {
+        title: params.title,
+        ...(params.notes !== undefined && { notes: params.notes }),
+        ...(params.due !== undefined && { due: params.due }),
+      };
+
+      const response = await tasks.tasks.insert({
+        tasklist: params.taskListId,
+        requestBody,
+      });
+
+      logToFile(`Successfully created task: ${response.data.id}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(response.data),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logToFile(`Error during tasks.create: ${errorMessage}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ error: errorMessage }),
+          },
+        ],
+      };
+    }
+  };
+
+  /**
+   * Updates an existing task.
+   */
+  updateTask = async (params: {
+    taskListId: string;
+    taskId: string;
+    title?: string;
+    notes?: string;
+    status?: 'needsAction' | 'completed';
+    due?: string;
+  }) => {
+    logToFile(`Updating task ${params.taskId} in list: ${params.taskListId}`);
+    try {
+      const tasks = await this.getTasksClient();
+      const requestBody: tasks_v1.Schema$Task = {
+        ...(params.title !== undefined && { title: params.title }),
+        ...(params.notes !== undefined && { notes: params.notes }),
+        ...(params.status !== undefined && { status: params.status }),
+        ...(params.due !== undefined && { due: params.due }),
+      };
+
+      const response = await tasks.tasks.patch({
+        tasklist: params.taskListId,
+        task: params.taskId,
+        requestBody,
+      });
+
+      logToFile(`Successfully updated task: ${params.taskId}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(response.data),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logToFile(`Error during tasks.update: ${errorMessage}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ error: errorMessage }),
+          },
+        ],
+      };
+    }
+  };
+
+  /**
+   * Completes a task (convenience wrapper around update).
+   */
+  completeTask = async (params: { taskListId: string; taskId: string }) => {
+    return this.updateTask({
+      taskListId: params.taskListId,
+      taskId: params.taskId,
+      status: 'completed',
+    });
+  };
+
+  /**
+   * Deletes a task.
+   */
+  deleteTask = async (params: { taskListId: string; taskId: string }) => {
+    logToFile(`Deleting task ${params.taskId} from list: ${params.taskListId}`);
+    try {
+      const tasks = await this.getTasksClient();
+      await tasks.tasks.delete({
+        tasklist: params.taskListId,
+        task: params.taskId,
+      });
+
+      logToFile(`Successfully deleted task: ${params.taskId}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: `Task ${params.taskId} deleted successfully from list ${params.taskListId}.`,
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logToFile(`Error during tasks.delete: ${errorMessage}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ error: errorMessage }),
+          },
+        ],
+      };
+    }
+  };
+}


### PR DESCRIPTION
## Summary

Adds full support for Google Tasks, rebased onto current `main` and integrated with the feature-configuration service so it ships safely disabled-by-default.

- Implements `TasksService` with private `getTasksClient()` following the same pattern as other services
- Registers 6 new tools: `tasks.listLists`, `tasks.list`, `tasks.create`, `tasks.update`, `tasks.complete`, `tasks.delete`
- **Gated behind the feature configuration service (#284):** tools are registered via the feature-gated `registerTool` wrapper, and the `tasks.read` / `tasks.write` groups are populated in `feature-config.ts` with `defaultEnabled: false`
- Full error handling with try/catch and logging on all methods
- Updates `WORKSPACE-Context.md` with Google Tasks behavioral guidance

Replaces #106 (which predated the current codebase structure).

### Safe-by-default for existing users

Both tasks feature groups are `defaultEnabled: false`, so `getAllPossibleScopes()` excludes the Tasks scopes from the OAuth consent set. Users on Google's published GCP project see **no change** to the scopes requested — the Tasks tools and the `tasks` scope only activate under `WORKSPACE_FEATURE_OVERRIDES="tasks.read:on,tasks.write:on"`.

Fixes #105

## Test plan

- [x] 14 unit tests covering all 6 methods including error handling
- [x] `npm run test` — all 29 suites / 589 tests pass
- [x] `npm run lint` — clean
- [x] `npm run format:check` — clean
- [x] Verified gating: by default 0 Tasks tools exposed and 0 Tasks scopes requested; with `WORKSPACE_FEATURE_OVERRIDES="tasks.read:on,tasks.write:on"` all 6 tools appear and the `tasks` scope is requested
