### PR TITLE
fix(calendar): tighten createEvent validation for event types

### DIFF
--- a/workspace-server/src/__tests__/services/CalendarService.test.ts
+++ b/workspace-server/src/__tests__/services/CalendarService.test.ts
@@ -1567,6 +1567,38 @@ describe('CalendarService', () => {
     });
   });
 
+  describe('updateEvent start/end validation', () => {
+    it('should reject start with both dateTime and date', async () => {
+      const result = await calendarService.updateEvent({
+        eventId: 'event1',
+        start: { dateTime: '2024-01-15T10:00:00Z', date: '2024-01-15' },
+      });
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.error).toBe('Invalid input format');
+    });
+
+    it('should reject end with both dateTime and date', async () => {
+      const result = await calendarService.updateEvent({
+        eventId: 'event1',
+        end: { dateTime: '2024-01-15T12:00:00Z', date: '2024-01-15' },
+      });
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.error).toBe('Invalid input format');
+    });
+
+    it('should reject start with neither dateTime nor date', async () => {
+      const result = await calendarService.updateEvent({
+        eventId: 'event1',
+        start: {},
+      });
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.error).toBe('Invalid input format');
+    });
+  });
+
   describe('listEvents with eventTypes', () => {
     beforeEach(async () => {
       mockCalendarAPI.calendarList.list.mockResolvedValue({

--- a/workspace-server/src/__tests__/services/CalendarService.test.ts
+++ b/workspace-server/src/__tests__/services/CalendarService.test.ts
@@ -2088,5 +2088,72 @@ describe('CalendarService', () => {
       const parsedResult = JSON.parse(result.content[0].text);
       expect(parsedResult.error).toBe('Invalid input format');
     });
+
+    it('should reject start with both dateTime and date', async () => {
+      const result = await calendarService.createEvent({
+        summary: 'Ambiguous Event',
+        start: { dateTime: '2024-01-15T10:00:00Z', date: '2024-01-15' },
+        end: { dateTime: '2024-01-15T12:00:00Z' },
+      });
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.error).toBe('Invalid input format');
+    });
+
+    it('should reject end with both dateTime and date', async () => {
+      const result = await calendarService.createEvent({
+        summary: 'Ambiguous Event',
+        start: { dateTime: '2024-01-15T10:00:00Z' },
+        end: { dateTime: '2024-01-15T12:00:00Z', date: '2024-01-15' },
+      });
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.error).toBe('Invalid input format');
+    });
+
+    it('should require summary for regular events', async () => {
+      const result = await calendarService.createEvent({
+        start: { dateTime: '2024-01-15T10:00:00Z' },
+        end: { dateTime: '2024-01-15T12:00:00Z' },
+      });
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.error).toBe('Invalid input format');
+    });
+
+    it('should require summary for explicit default eventType', async () => {
+      const result = await calendarService.createEvent({
+        start: { dateTime: '2024-01-15T10:00:00Z' },
+        end: { dateTime: '2024-01-15T12:00:00Z' },
+        eventType: 'default',
+      });
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.error).toBe('Invalid input format');
+    });
+
+    it('should reject officeLocation type without officeLocation details', async () => {
+      const result = await calendarService.createEvent({
+        start: { date: '2024-01-15' },
+        end: { date: '2024-01-16' },
+        eventType: 'workingLocation',
+        workingLocationProperties: { type: 'officeLocation' },
+      });
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.error).toBe('Invalid input format');
+    });
+
+    it('should reject customLocation type without customLocation details', async () => {
+      const result = await calendarService.createEvent({
+        start: { date: '2024-01-15' },
+        end: { date: '2024-01-16' },
+        eventType: 'workingLocation',
+        workingLocationProperties: { type: 'customLocation' },
+      });
+
+      const parsedResult = JSON.parse(result.content[0].text);
+      expect(parsedResult.error).toBe('Invalid input format');
+    });
   });
 });

--- a/workspace-server/src/services/CalendarService.ts
+++ b/workspace-server/src/services/CalendarService.ts
@@ -672,6 +672,34 @@ export class CalendarService {
       attachments,
     } = input;
 
+    // Validate start/end: if provided, exactly one of dateTime or date
+    if (start) {
+      if ((start.dateTime && start.date) || (!start.dateTime && !start.date)) {
+        return this.createValidationErrorResponse(
+          new z.ZodError([
+            {
+              code: 'custom',
+              message: 'start must have exactly one of "dateTime" or "date"',
+              path: ['start'],
+            },
+          ]),
+        );
+      }
+    }
+    if (end) {
+      if ((end.dateTime && end.date) || (!end.dateTime && !end.date)) {
+        return this.createValidationErrorResponse(
+          new z.ZodError([
+            {
+              code: 'custom',
+              message: 'end must have exactly one of "dateTime" or "date"',
+              path: ['end'],
+            },
+          ]),
+        );
+      }
+    }
+
     // Validate datetime formats if provided
     try {
       if (start?.dateTime !== undefined) {

--- a/workspace-server/src/services/CalendarService.ts
+++ b/workspace-server/src/services/CalendarService.ts
@@ -260,15 +260,33 @@ export class CalendarService {
     const summary =
       input.summary ?? (eventType ? summaryDefaults[eventType] : undefined);
 
-    // Validate start/end: at least one of dateTime or date must be provided
-    if ((!start.dateTime && !start.date) || (!end.dateTime && !end.date)) {
+    // Validate start/end: exactly one of dateTime or date must be provided
+    if (
+      (!start.dateTime && !start.date) ||
+      (!end.dateTime && !end.date) ||
+      (start.dateTime && start.date) ||
+      (end.dateTime && end.date)
+    ) {
       return this.createValidationErrorResponse(
         new z.ZodError([
           {
             code: 'custom',
             message:
-              'start and end must each have either "dateTime" (for timed events) or "date" (for all-day events)',
+              'start and end must each have exactly one of "dateTime" (for timed events) or "date" (for all-day events), not both',
             path: ['start/end'],
+          },
+        ]),
+      );
+    }
+
+    // Require summary for regular events
+    if ((!eventType || eventType === 'default') && !input.summary) {
+      return this.createValidationErrorResponse(
+        new z.ZodError([
+          {
+            code: 'custom',
+            message: 'summary is required for regular events',
+            path: ['summary'],
           },
         ]),
       );
@@ -388,18 +406,36 @@ export class CalendarService {
         };
         if (wlInput.type === 'homeOffice') {
           wlProps.homeOffice = {};
-        } else if (
-          wlInput.type === 'officeLocation' &&
-          wlInput.officeLocation
-        ) {
+        } else if (wlInput.type === 'officeLocation') {
+          if (!wlInput.officeLocation) {
+            return this.createValidationErrorResponse(
+              new z.ZodError([
+                {
+                  code: 'custom',
+                  message:
+                    'officeLocation is required when workingLocationProperties.type is "officeLocation"',
+                  path: ['workingLocationProperties', 'officeLocation'],
+                },
+              ]),
+            );
+          }
           wlProps.officeLocation = {
             buildingId: wlInput.officeLocation.buildingId,
             label: wlInput.officeLocation.label,
           };
-        } else if (
-          wlInput.type === 'customLocation' &&
-          wlInput.customLocation
-        ) {
+        } else if (wlInput.type === 'customLocation') {
+          if (!wlInput.customLocation) {
+            return this.createValidationErrorResponse(
+              new z.ZodError([
+                {
+                  code: 'custom',
+                  message:
+                    'customLocation is required when workingLocationProperties.type is "customLocation"',
+                  path: ['workingLocationProperties', 'customLocation'],
+                },
+              ]),
+            );
+          }
           wlProps.customLocation = {
             label: wlInput.customLocation.label,
           };
@@ -613,10 +649,10 @@ export class CalendarService {
 
     // Validate datetime formats if provided
     try {
-      if (start) {
+      if (start?.dateTime) {
         iso8601DateTimeSchema.parse(start.dateTime);
       }
-      if (end) {
+      if (end?.dateTime) {
         iso8601DateTimeSchema.parse(end.dateTime);
       }
       if (attendees) {

--- a/workspace-server/src/services/CalendarService.ts
+++ b/workspace-server/src/services/CalendarService.ts
@@ -260,20 +260,29 @@ export class CalendarService {
     const summary =
       input.summary ?? (eventType ? summaryDefaults[eventType] : undefined);
 
-    // Validate start/end: exactly one of dateTime or date must be provided
-    if (
-      (!start.dateTime && !start.date) ||
-      (!end.dateTime && !end.date) ||
-      (start.dateTime && start.date) ||
-      (end.dateTime && end.date)
-    ) {
+    // Validate start: exactly one of dateTime or date must be provided
+    if ((!start.dateTime && !start.date) || (start.dateTime && start.date)) {
       return this.createValidationErrorResponse(
         new z.ZodError([
           {
             code: 'custom',
             message:
-              'start and end must each have exactly one of "dateTime" (for timed events) or "date" (for all-day events), not both',
-            path: ['start/end'],
+              'start must have exactly one of "dateTime" (for timed events) or "date" (for all-day events)',
+            path: ['start'],
+          },
+        ]),
+      );
+    }
+
+    // Validate end: exactly one of dateTime or date must be provided
+    if ((!end.dateTime && !end.date) || (end.dateTime && end.date)) {
+      return this.createValidationErrorResponse(
+        new z.ZodError([
+          {
+            code: 'custom',
+            message:
+              'end must have exactly one of "dateTime" (for timed events) or "date" (for all-day events)',
+            path: ['end'],
           },
         ]),
       );
@@ -320,6 +329,40 @@ export class CalendarService {
           },
         ]),
       );
+    }
+
+    // Validate working location sub-properties match the declared type
+    if (eventType === 'workingLocation' && workingLocationProperties) {
+      if (
+        workingLocationProperties.type === 'officeLocation' &&
+        !workingLocationProperties.officeLocation
+      ) {
+        return this.createValidationErrorResponse(
+          new z.ZodError([
+            {
+              code: 'custom',
+              message:
+                'officeLocation is required when workingLocationProperties.type is "officeLocation"',
+              path: ['workingLocationProperties', 'officeLocation'],
+            },
+          ]),
+        );
+      }
+      if (
+        workingLocationProperties.type === 'customLocation' &&
+        !workingLocationProperties.customLocation
+      ) {
+        return this.createValidationErrorResponse(
+          new z.ZodError([
+            {
+              code: 'custom',
+              message:
+                'customLocation is required when workingLocationProperties.type is "customLocation"',
+              path: ['workingLocationProperties', 'customLocation'],
+            },
+          ]),
+        );
+      }
     }
 
     // Validate datetime formats (skip for date-only / all-day events)
@@ -406,36 +449,18 @@ export class CalendarService {
         };
         if (wlInput.type === 'homeOffice') {
           wlProps.homeOffice = {};
-        } else if (wlInput.type === 'officeLocation') {
-          if (!wlInput.officeLocation) {
-            return this.createValidationErrorResponse(
-              new z.ZodError([
-                {
-                  code: 'custom',
-                  message:
-                    'officeLocation is required when workingLocationProperties.type is "officeLocation"',
-                  path: ['workingLocationProperties', 'officeLocation'],
-                },
-              ]),
-            );
-          }
+        } else if (
+          wlInput.type === 'officeLocation' &&
+          wlInput.officeLocation
+        ) {
           wlProps.officeLocation = {
             buildingId: wlInput.officeLocation.buildingId,
             label: wlInput.officeLocation.label,
           };
-        } else if (wlInput.type === 'customLocation') {
-          if (!wlInput.customLocation) {
-            return this.createValidationErrorResponse(
-              new z.ZodError([
-                {
-                  code: 'custom',
-                  message:
-                    'customLocation is required when workingLocationProperties.type is "customLocation"',
-                  path: ['workingLocationProperties', 'customLocation'],
-                },
-              ]),
-            );
-          }
+        } else if (
+          wlInput.type === 'customLocation' &&
+          wlInput.customLocation
+        ) {
           wlProps.customLocation = {
             label: wlInput.customLocation.label,
           };
@@ -649,10 +674,10 @@ export class CalendarService {
 
     // Validate datetime formats if provided
     try {
-      if (start?.dateTime) {
+      if (start?.dateTime !== undefined) {
         iso8601DateTimeSchema.parse(start.dateTime);
       }
-      if (end?.dateTime) {
+      if (end?.dateTime !== undefined) {
         iso8601DateTimeSchema.parse(end.dateTime);
       }
       if (attendees) {


### PR DESCRIPTION
## Summary

Follow-up to #290 — tightens validation in `createEvent` to catch edge cases that could produce confusing API behavior:

- **Reject ambiguous start/end**: If both `dateTime` and `date` are provided, reject instead of letting the Google API pick one
- **Require summary for regular events**: `summary` was made optional in #290 to support status event defaults, but regular events (no `eventType` or `eventType: "default"`) should still require it
- **Validate working location sub-properties**: `officeLocation` details are now required when `type` is `"officeLocation"`, and `customLocation` details when `type` is `"customLocation"`
- **Fix updateEvent for all-day events**: `updateEvent` was unconditionally validating `start.dateTime` even for date-only updates

## Test plan

- [x] 7 new test cases covering all validation scenarios
- [x] All 74 calendar service tests pass
- [x] Lint and format checks pass