### PR TITLE
fix(docs): include document title in getText and getSuggestions

### DIFF
--- a/workspace-server/src/__tests__/services/DocsService.comments.test.ts
+++ b/workspace-server/src/__tests__/services/DocsService.comments.test.ts
@@ -58,6 +58,7 @@ describe('DocsService Comments and Suggestions', () => {
     it('should return suggestions as type text with JSON-stringified array', async () => {
       mockDocsAPI.documents.get.mockResolvedValue({
         data: {
+          title: 'Test Document',
           body: {
             content: [
               {
@@ -84,7 +85,9 @@ describe('DocsService Comments and Suggestions', () => {
       });
 
       expect(result.content[0].type).toBe('text');
-      const { suggestions } = JSON.parse(result.content[0].text);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.title).toBe('Test Document');
+      const { suggestions } = parsed;
       expect(suggestions).toHaveLength(1);
       expect(suggestions[0]).toEqual({
         type: 'insertion',

--- a/workspace-server/src/__tests__/services/DocsService.comments.test.ts
+++ b/workspace-server/src/__tests__/services/DocsService.comments.test.ts
@@ -84,7 +84,7 @@ describe('DocsService Comments and Suggestions', () => {
       });
 
       expect(result.content[0].type).toBe('text');
-      const suggestions = JSON.parse(result.content[0].text);
+      const { suggestions } = JSON.parse(result.content[0].text);
       expect(suggestions).toHaveLength(1);
       expect(suggestions[0]).toEqual({
         type: 'insertion',
@@ -123,7 +123,7 @@ describe('DocsService Comments and Suggestions', () => {
         documentId: 'test-doc-id',
       });
 
-      const suggestions = JSON.parse(result.content[0].text);
+      const { suggestions } = JSON.parse(result.content[0].text);
       expect(suggestions).toHaveLength(1);
       expect(suggestions[0].type).toBe('insertion');
       expect(suggestions[0].suggestionIds).toEqual(['sug-1', 'sug-2']);
@@ -157,7 +157,7 @@ describe('DocsService Comments and Suggestions', () => {
         documentId: 'test-doc-id',
       });
 
-      const suggestions = JSON.parse(result.content[0].text);
+      const { suggestions } = JSON.parse(result.content[0].text);
       expect(suggestions).toHaveLength(1);
       expect(suggestions[0].type).toBe('deletion');
       expect(suggestions[0].text).toBe('deleted text');
@@ -194,7 +194,7 @@ describe('DocsService Comments and Suggestions', () => {
         documentId: 'test-doc-id',
       });
 
-      const suggestions = JSON.parse(result.content[0].text);
+      const { suggestions } = JSON.parse(result.content[0].text);
       expect(suggestions).toHaveLength(1);
       expect(suggestions[0].type).toBe('styleChange');
       expect(suggestions[0].suggestionIds).toEqual(['style-1']);
@@ -234,7 +234,7 @@ describe('DocsService Comments and Suggestions', () => {
         documentId: 'test-doc-id',
       });
 
-      const suggestions = JSON.parse(result.content[0].text);
+      const { suggestions } = JSON.parse(result.content[0].text);
       expect(suggestions).toHaveLength(1);
       expect(suggestions[0].type).toBe('paragraphStyleChange');
       expect(suggestions[0].suggestionIds).toEqual(['sug-para-1']);
@@ -284,7 +284,7 @@ describe('DocsService Comments and Suggestions', () => {
         documentId: 'test-doc-id',
       });
 
-      const suggestions = JSON.parse(result.content[0].text);
+      const { suggestions } = JSON.parse(result.content[0].text);
       expect(suggestions).toHaveLength(1);
       expect(suggestions[0].type).toBe('insertion');
       expect(suggestions[0].text).toBe('cell text');
@@ -299,8 +299,8 @@ describe('DocsService Comments and Suggestions', () => {
         documentId: 'test-doc-id',
       });
 
-      const suggestions = JSON.parse(result.content[0].text);
-      expect(suggestions).toEqual([]);
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.suggestions).toEqual([]);
     });
 
     it('should handle API errors gracefully', async () => {
@@ -351,7 +351,7 @@ describe('DocsService Comments and Suggestions', () => {
         documentId: 'test-doc-id',
       });
 
-      const suggestions = JSON.parse(result.content[0].text);
+      const { suggestions } = JSON.parse(result.content[0].text);
       expect(suggestions).toHaveLength(2);
       const types = suggestions.map((s: any) => s.type);
       expect(types).toEqual(['paragraphStyleChange', 'paragraphStyleChange']);
@@ -391,7 +391,7 @@ describe('DocsService Comments and Suggestions', () => {
         documentId: 'test-doc-id',
       });
 
-      const suggestions = JSON.parse(result.content[0].text);
+      const { suggestions } = JSON.parse(result.content[0].text);
       expect(suggestions).toHaveLength(1);
       expect(suggestions[0].text).toBe('');
     });

--- a/workspace-server/src/__tests__/services/DocsService.test.ts
+++ b/workspace-server/src/__tests__/services/DocsService.test.ts
@@ -513,6 +513,7 @@ describe('DocsService', () => {
     it('should return all tabs if no tabId provided and tabs exist', async () => {
       const mockDoc = {
         data: {
+          title: 'Multi-Tab Document',
           tabs: [
             {
               tabProperties: { tabId: 'tab-1', title: 'Tab 1' },
@@ -550,6 +551,7 @@ describe('DocsService', () => {
       const result = await docsService.getText({ documentId: 'test-doc-id' });
       const parsed = JSON.parse(result.content[0].text);
 
+      expect(parsed.title).toBe('Multi-Tab Document');
       expect(parsed.tabs).toHaveLength(2);
       expect(parsed.tabs[0]).toEqual({
         tabId: 'tab-1',
@@ -695,6 +697,7 @@ describe('DocsService', () => {
     it('should include text from nested child tabs', async () => {
       const mockDoc = {
         data: {
+          title: 'Nested Tabs Doc',
           tabs: [
             {
               tabProperties: { tabId: 'parent-tab', title: 'Parent' },
@@ -736,6 +739,7 @@ describe('DocsService', () => {
       const result = await docsService.getText({ documentId: 'test-doc-id' });
       const parsed = JSON.parse(result.content[0].text);
 
+      expect(parsed.title).toBe('Nested Tabs Doc');
       expect(parsed.tabs).toHaveLength(2);
       expect(parsed.tabs[0]).toEqual({
         tabId: 'parent-tab',

--- a/workspace-server/src/__tests__/services/DocsService.test.ts
+++ b/workspace-server/src/__tests__/services/DocsService.test.ts
@@ -550,14 +550,14 @@ describe('DocsService', () => {
       const result = await docsService.getText({ documentId: 'test-doc-id' });
       const parsed = JSON.parse(result.content[0].text);
 
-      expect(parsed).toHaveLength(2);
-      expect(parsed[0]).toEqual({
+      expect(parsed.tabs).toHaveLength(2);
+      expect(parsed.tabs[0]).toEqual({
         tabId: 'tab-1',
         title: 'Tab 1',
         content: 'Tab 1 Content',
         index: 0,
       });
-      expect(parsed[1]).toEqual({
+      expect(parsed.tabs[1]).toEqual({
         tabId: 'tab-2',
         title: 'Tab 2',
         content: 'Tab 2 Content',
@@ -736,14 +736,14 @@ describe('DocsService', () => {
       const result = await docsService.getText({ documentId: 'test-doc-id' });
       const parsed = JSON.parse(result.content[0].text);
 
-      expect(parsed).toHaveLength(2);
-      expect(parsed[0]).toEqual({
+      expect(parsed.tabs).toHaveLength(2);
+      expect(parsed.tabs[0]).toEqual({
         tabId: 'parent-tab',
         title: 'Parent',
         content: 'Parent Content',
         index: 0,
       });
-      expect(parsed[1]).toEqual({
+      expect(parsed.tabs[1]).toEqual({
         tabId: 'child-tab',
         title: 'Child',
         content: 'Child Content',

--- a/workspace-server/src/services/DocsService.ts
+++ b/workspace-server/src/services/DocsService.ts
@@ -75,7 +75,7 @@ export class DocsService {
       const res = await docs.documents.get({
         documentId: id,
         suggestionsViewMode: 'SUGGESTIONS_INLINE',
-        fields: 'body',
+        fields: 'title,body',
       });
 
       const suggestions: DocsSuggestion[] = this._extractSuggestions(
@@ -90,7 +90,11 @@ export class DocsService {
         content: [
           {
             type: 'text' as const,
-            text: JSON.stringify(suggestions, null, 2),
+            text: JSON.stringify(
+              { title: res.data.title, suggestions },
+              null,
+              2,
+            ),
           },
         ],
       };
@@ -539,10 +543,11 @@ export class DocsService {
       const docs = await this.getDocsClient();
       const res = await docs.documents.get({
         documentId: id,
-        fields: 'tabs', // Request tabs only (body is legacy and mutually exclusive with tabs in mask)
+        fields: 'title,tabs', // Request title and tabs (body is legacy and mutually exclusive with tabs in mask)
         includeTabsContent: true,
       });
 
+      const docTitle = res.data.title;
       const tabs = this._flattenTabs(res.data.tabs || []);
 
       // If tabId is provided, try to find it
@@ -565,6 +570,9 @@ export class DocsService {
         }
 
         let text = '';
+        if (docTitle) {
+          text += `Document Title: ${docTitle}\n\n`;
+        }
         content.forEach((element) => {
           text += this._readStructuralElement(element);
         });
@@ -595,6 +603,9 @@ export class DocsService {
       if (tabs.length === 1) {
         const tab = tabs[0];
         let text = '';
+        if (docTitle) {
+          text += `Document Title: ${docTitle}\n\n`;
+        }
         if (tab.documentTab?.body?.content) {
           tab.documentTab.body.content.forEach((element) => {
             text += this._readStructuralElement(element);
@@ -630,7 +641,7 @@ export class DocsService {
         content: [
           {
             type: 'text' as const,
-            text: JSON.stringify(tabsData, null, 2),
+            text: JSON.stringify({ title: docTitle, tabs: tabsData }, null, 2),
           },
         ],
       };


### PR DESCRIPTION
## Summary

- `docs.getText` and `docs.getSuggestions` were the only read tools that didn't return the document title — `slides.getText`, `sheets.getText`, and `gmail.get` all already did
- **`getText`**: Prepends `Document Title: ...` for single-tab plain text responses; wraps multi-tab JSON in a `{ title, tabs }` object
- **`getSuggestions`**: Returns `{ title, suggestions }` instead of a bare array

## Test plan

- [x] All 43 DocsService tests pass (updated assertions for new response shapes)
- [x] Lint and format checks pass