### PR TITLE
feat(sheets): add sheets.appendRow write tool

### DIFF
--- a/docs/feature-configuration.md
+++ b/docs/feature-configuration.md
@@ -197,6 +197,10 @@ When a feature group is disabled:
 - `sheets.getRange`
 - `sheets.getMetadata`
 
+### `sheets.write`
+
+- `sheets.appendRows`
+
 ### `time.read`
 
 - `time.getCurrentDate`

--- a/docs/index.md
+++ b/docs/index.md
@@ -40,6 +40,7 @@ The extension provides the following tools:
 - `sheets.getRange`: Gets values from a specific range in a Google Sheets
   spreadsheet.
 - `sheets.getMetadata`: Gets metadata about a Google Sheets spreadsheet.
+- `sheets.appendRows`: Appends rows to a Google Sheets spreadsheet.
 
 ### Google Drive
 

--- a/workspace-server/src/__tests__/services/SheetsService.test.ts
+++ b/workspace-server/src/__tests__/services/SheetsService.test.ts
@@ -40,6 +40,7 @@ describe('SheetsService', () => {
         get: jest.fn(),
         values: {
           get: jest.fn(),
+          append: jest.fn(),
         },
       },
     };
@@ -368,6 +369,73 @@ describe('SheetsService', () => {
       const response = JSON.parse(result.content[0].text);
 
       expect(response.error).toBe('Metadata Error');
+    });
+  });
+
+  describe('appendRow', () => {
+    it('should append rows and return update info', async () => {
+      const mockResponse = {
+        data: {
+          updates: {
+            updatedRange: 'Sheet1!A3:B3',
+            updatedRows: 1,
+            updatedColumns: 2,
+            updatedCells: 2,
+          },
+        },
+      };
+
+      mockSheetsAPI.spreadsheets.values.append.mockResolvedValue(mockResponse);
+
+      const result = await sheetsService.appendRow({
+        spreadsheetId: 'test-id',
+        range: 'Sheet1!A1',
+        values: [['foo', 'bar']],
+      });
+      const response = JSON.parse(result.content[0].text);
+
+      expect(mockSheetsAPI.spreadsheets.values.append).toHaveBeenCalledWith({
+        spreadsheetId: 'test-id',
+        range: 'Sheet1!A1',
+        valueInputOption: 'USER_ENTERED',
+        requestBody: { values: [['foo', 'bar']] },
+      });
+
+      expect(response.updatedRange).toBe('Sheet1!A3:B3');
+      expect(response.updatedRows).toBe(1);
+      expect(response.updatedColumns).toBe(2);
+      expect(response.updatedCells).toBe(2);
+    });
+
+    it('should extract spreadsheet ID from URL', async () => {
+      mockSheetsAPI.spreadsheets.values.append.mockResolvedValue({
+        data: { updates: { updatedRange: 'Sheet1!A2:A2', updatedRows: 1, updatedColumns: 1, updatedCells: 1 } },
+      });
+
+      await sheetsService.appendRow({
+        spreadsheetId: 'https://docs.google.com/spreadsheets/d/abc123/edit',
+        range: 'Sheet1!A1',
+        values: [['value']],
+      });
+
+      expect(mockSheetsAPI.spreadsheets.values.append).toHaveBeenCalledWith(
+        expect.objectContaining({ spreadsheetId: 'abc123' }),
+      );
+    });
+
+    it('should handle errors gracefully', async () => {
+      mockSheetsAPI.spreadsheets.values.append.mockRejectedValue(
+        new Error('Append Error'),
+      );
+
+      const result = await sheetsService.appendRow({
+        spreadsheetId: 'error-id',
+        range: 'Sheet1!A1',
+        values: [['data']],
+      });
+      const response = JSON.parse(result.content[0].text);
+
+      expect(response.error).toBe('Append Error');
     });
   });
 });

--- a/workspace-server/src/__tests__/services/SheetsService.test.ts
+++ b/workspace-server/src/__tests__/services/SheetsService.test.ts
@@ -413,14 +413,30 @@ describe('SheetsService', () => {
       });
 
       await sheetsService.appendRows({
-        spreadsheetId: 'https://docs.google.com/spreadsheets/d/abc123/edit',
+        spreadsheetId: 'https://docs.google.com/spreadsheets/d/1A2b-_C3dEfGhIjKlMnOpQr/edit',
         range: 'Sheet1!A1',
         values: [['value']],
       });
 
       expect(mockSheetsAPI.spreadsheets.values.append).toHaveBeenCalledWith(
-        expect.objectContaining({ spreadsheetId: 'abc123' }),
+        expect.objectContaining({ spreadsheetId: '1A2b-_C3dEfGhIjKlMnOpQr' }),
       );
+    });
+
+    it('should return isError when updates metadata is missing', async () => {
+      mockSheetsAPI.spreadsheets.values.append.mockResolvedValue({
+        data: {},
+      });
+
+      const result = await sheetsService.appendRows({
+        spreadsheetId: 'test-id',
+        range: 'Sheet1!A1',
+        values: [['value']],
+      });
+      const response = JSON.parse(result.content[0].text);
+
+      expect(result.isError).toBe(true);
+      expect(response.error).toMatch(/no update information/);
     });
 
     it('should handle errors gracefully', async () => {
@@ -435,6 +451,7 @@ describe('SheetsService', () => {
       });
       const response = JSON.parse(result.content[0].text);
 
+      expect(result.isError).toBe(true);
       expect(response.error).toBe('Append Error');
     });
   });

--- a/workspace-server/src/__tests__/services/SheetsService.test.ts
+++ b/workspace-server/src/__tests__/services/SheetsService.test.ts
@@ -372,7 +372,7 @@ describe('SheetsService', () => {
     });
   });
 
-  describe('appendRow', () => {
+  describe('appendRows', () => {
     it('should append rows and return update info', async () => {
       const mockResponse = {
         data: {
@@ -387,7 +387,7 @@ describe('SheetsService', () => {
 
       mockSheetsAPI.spreadsheets.values.append.mockResolvedValue(mockResponse);
 
-      const result = await sheetsService.appendRow({
+      const result = await sheetsService.appendRows({
         spreadsheetId: 'test-id',
         range: 'Sheet1!A1',
         values: [['foo', 'bar']],
@@ -412,7 +412,7 @@ describe('SheetsService', () => {
         data: { updates: { updatedRange: 'Sheet1!A2:A2', updatedRows: 1, updatedColumns: 1, updatedCells: 1 } },
       });
 
-      await sheetsService.appendRow({
+      await sheetsService.appendRows({
         spreadsheetId: 'https://docs.google.com/spreadsheets/d/abc123/edit',
         range: 'Sheet1!A1',
         values: [['value']],
@@ -428,7 +428,7 @@ describe('SheetsService', () => {
         new Error('Append Error'),
       );
 
-      const result = await sheetsService.appendRow({
+      const result = await sheetsService.appendRows({
         spreadsheetId: 'error-id',
         range: 'Sheet1!A1',
         values: [['data']],

--- a/workspace-server/src/features/feature-config.ts
+++ b/workspace-server/src/features/feature-config.ts
@@ -226,7 +226,7 @@ export const FEATURE_GROUPS: readonly FeatureGroup[] = [
     service: 'sheets',
     group: 'write',
     scopes: scopes('spreadsheets'),
-    tools: ['sheets.appendRow'],
+    tools: ['sheets.appendRows'],
     defaultEnabled: false,
   },
 

--- a/workspace-server/src/features/feature-config.ts
+++ b/workspace-server/src/features/feature-config.ts
@@ -226,7 +226,7 @@ export const FEATURE_GROUPS: readonly FeatureGroup[] = [
     service: 'sheets',
     group: 'write',
     scopes: scopes('spreadsheets'),
-    tools: [],
+    tools: ['sheets.appendRow'],
     defaultEnabled: false,
   },
 

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -519,6 +519,7 @@ async function main() {
           ),
         values: z
           .array(z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])))
+          .min(1)
           .describe(
             'A 2D array of values to append. Each inner array is a row (e.g., [["col1", "col2"], ["val1", "val2"]]).',
           ),

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -506,7 +506,7 @@ async function main() {
   );
 
   registerTool(
-    'sheets.appendRow',
+    'sheets.appendRows',
     {
       description:
         'Appends rows to a Google Sheets spreadsheet after the last row with data in the given range.',
@@ -518,13 +518,13 @@ async function main() {
             'The A1 notation range to append to (e.g., "Sheet1!A1"). Data is appended after the last row with data in this range.',
           ),
         values: z
-          .array(z.array(z.string()))
+          .array(z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])))
           .describe(
             'A 2D array of values to append. Each inner array is a row (e.g., [["col1", "col2"], ["val1", "val2"]]).',
           ),
       },
     },
-    sheetsService.appendRow,
+    sheetsService.appendRows,
   );
 
   registerTool(

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -506,6 +506,28 @@ async function main() {
   );
 
   registerTool(
+    'sheets.appendRow',
+    {
+      description:
+        'Appends rows to a Google Sheets spreadsheet after the last row with data in the given range.',
+      inputSchema: {
+        spreadsheetId: z.string().describe('The ID or URL of the spreadsheet.'),
+        range: z
+          .string()
+          .describe(
+            'The A1 notation range to append to (e.g., "Sheet1!A1"). Data is appended after the last row with data in this range.',
+          ),
+        values: z
+          .array(z.array(z.string()))
+          .describe(
+            'A 2D array of values to append. Each inner array is a row (e.g., [["col1", "col2"], ["val1", "val2"]]).',
+          ),
+      },
+    },
+    sheetsService.appendRow,
+  );
+
+  registerTool(
     'drive.search',
     {
       description:

--- a/workspace-server/src/services/SheetsService.ts
+++ b/workspace-server/src/services/SheetsService.ts
@@ -194,17 +194,17 @@ export class SheetsService {
     }
   };
 
-  public appendRow = async ({
+  public appendRows = async ({
     spreadsheetId,
     range,
     values,
   }: {
     spreadsheetId: string;
     range: string;
-    values: string[][];
+    values: (string | number | boolean | null)[][];
   }) => {
     logToFile(
-      `[SheetsService] Starting appendRow for spreadsheet: ${spreadsheetId}, range: ${range}`,
+      `[SheetsService] Starting appendRows for spreadsheet: ${spreadsheetId}, range: ${range}`,
     );
     try {
       const id = extractDocId(spreadsheetId) || spreadsheetId;
@@ -219,7 +219,7 @@ export class SheetsService {
         },
       });
 
-      logToFile(`[SheetsService] Finished appendRow for spreadsheet: ${id}`);
+      logToFile(`[SheetsService] Finished appendRows for spreadsheet: ${id}`);
       return {
         content: [
           {
@@ -237,7 +237,7 @@ export class SheetsService {
       const errorMessage =
         error instanceof Error ? error.message : String(error);
       logToFile(
-        `[SheetsService] Error during sheets.appendRow: ${errorMessage}`,
+        `[SheetsService] Error during sheets.appendRows: ${errorMessage}`,
       );
       return {
         content: [

--- a/workspace-server/src/services/SheetsService.ts
+++ b/workspace-server/src/services/SheetsService.ts
@@ -219,16 +219,35 @@ export class SheetsService {
         },
       });
 
+      const updates = response.data.updates;
+      if (!updates) {
+        logToFile(
+          `[SheetsService] appendRows returned no update metadata for: ${id}`,
+        );
+        return {
+          isError: true,
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error:
+                  'Append returned no update information; rows may not have been written.',
+              }),
+            },
+          ],
+        };
+      }
+
       logToFile(`[SheetsService] Finished appendRows for spreadsheet: ${id}`);
       return {
         content: [
           {
             type: 'text' as const,
             text: JSON.stringify({
-              updatedRange: response.data.updates?.updatedRange,
-              updatedRows: response.data.updates?.updatedRows,
-              updatedColumns: response.data.updates?.updatedColumns,
-              updatedCells: response.data.updates?.updatedCells,
+              updatedRange: updates.updatedRange,
+              updatedRows: updates.updatedRows,
+              updatedColumns: updates.updatedColumns,
+              updatedCells: updates.updatedCells,
             }),
           },
         ],
@@ -240,6 +259,7 @@ export class SheetsService {
         `[SheetsService] Error during sheets.appendRows: ${errorMessage}`,
       );
       return {
+        isError: true,
         content: [
           {
             type: 'text' as const,

--- a/workspace-server/src/services/SheetsService.ts
+++ b/workspace-server/src/services/SheetsService.ts
@@ -194,6 +194,62 @@ export class SheetsService {
     }
   };
 
+  public appendRow = async ({
+    spreadsheetId,
+    range,
+    values,
+  }: {
+    spreadsheetId: string;
+    range: string;
+    values: string[][];
+  }) => {
+    logToFile(
+      `[SheetsService] Starting appendRow for spreadsheet: ${spreadsheetId}, range: ${range}`,
+    );
+    try {
+      const id = extractDocId(spreadsheetId) || spreadsheetId;
+
+      const sheets = await this.getSheetsClient();
+      const response = await sheets.spreadsheets.values.append({
+        spreadsheetId: id,
+        range: range,
+        valueInputOption: 'USER_ENTERED',
+        requestBody: {
+          values: values,
+        },
+      });
+
+      logToFile(`[SheetsService] Finished appendRow for spreadsheet: ${id}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              updatedRange: response.data.updates?.updatedRange,
+              updatedRows: response.data.updates?.updatedRows,
+              updatedColumns: response.data.updates?.updatedColumns,
+              updatedCells: response.data.updates?.updatedCells,
+            }),
+          },
+        ],
+      };
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      logToFile(
+        `[SheetsService] Error during sheets.appendRow: ${errorMessage}`,
+      );
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({ error: errorMessage }),
+          },
+        ],
+      };
+    }
+  };
+
   public getMetadata = async ({ spreadsheetId }: { spreadsheetId: string }) => {
     logToFile(
       `[SheetsService] Starting getMetadata for spreadsheet: ${spreadsheetId}`,


### PR DESCRIPTION
## Summary

- Adds `sheets.appendRow` MCP tool to append rows to a Google Sheets spreadsheet
- Tool is gated behind the sheets write feature group (`defaultEnabled: false`, requires `spreadsheets` OAuth scope)
- Uses `USER_ENTERED` value input option so formulas and dates are parsed correctly

## Test Plan

- [x] Unit tests added for success case, URL-to-ID extraction, and error handling (`SheetsService.test.ts`)
- [x] Run `npm run test && npm run lint` to verify all checks pass
- [x] Manually verify appending a row to a spreadsheet returns correct `updatedRange`, `updatedRows`, `updatedColumns`, `updatedCells`
- [x] Verify tool is disabled by default and only activates when sheets write feature is enabled

Issue #341 