### PR TITLE
fix(docs): resolve docs.getText API errors

### DIFF
--- a/scripts/setup-gcp.sh
+++ b/scripts/setup-gcp.sh
@@ -95,7 +95,7 @@ echo ""
 # workspace-server/src/features/feature-config.ts. See issue #323.
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-SCOPES_OUTPUT=$(cd "$REPO_ROOT" && npx --no-install ts-node --transpile-only scripts/print-scopes.ts 2>&1)
+SCOPES_OUTPUT=$(cd "$REPO_ROOT" && npx --no-install ts-node --transpile-only --project scripts/tsconfig.json scripts/print-scopes.ts 2>&1)
 if [ $? -ne 0 ]; then
     echo -e "${RED}Error: Failed to compute OAuth scopes from feature-config.ts.${NC}"
     echo -e "${RED}Did you run 'npm install' at the repo root?${NC}"

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".."
+  },
+  "include": ["**/*.ts", "../workspace-server/src/**/*"]
+}

--- a/skills/google-docs/SKILL.md
+++ b/skills/google-docs/SKILL.md
@@ -236,7 +236,7 @@ the destination by folder ID or folder name.
 
 ### Reading Comments
 
-Use `docs.getComments` to retrieve all comments on a document:
+Use `drive.getComments` to retrieve all comments on a document:
 
 - Returns comment threads with author, content, timestamp, and resolution status
 - Includes **threaded replies** with author, content, timestamp, and action
@@ -244,7 +244,7 @@ Use `docs.getComments` to retrieve all comments on a document:
 - Includes **quoted file content** showing what text the comment is anchored to
 
 ```
-docs.getComments({ documentId: "doc-id" })
+drive.getComments({ fileId: "doc-id" })
 ```
 
 ### Reading Suggestions

--- a/workspace-server/src/__tests__/features/feature-config.test.ts
+++ b/workspace-server/src/__tests__/features/feature-config.test.ts
@@ -105,7 +105,7 @@ describe('getAllPossibleScopes (issue #323)', () => {
     // execSync (not execFileSync) so Windows can resolve npx.cmd via the
     // shell. Tests run on ubuntu/macos/windows.
     const output = execSync(
-      'npx --no-install ts-node --transpile-only scripts/print-scopes.ts',
+      'npx --no-install ts-node --transpile-only --project scripts/tsconfig.json scripts/print-scopes.ts',
       { cwd: repoRoot, encoding: 'utf8' },
     );
     const printed = output.trim().split(/\r?\n/);

--- a/workspace-server/src/__tests__/services/DocsService.test.ts
+++ b/workspace-server/src/__tests__/services/DocsService.test.ts
@@ -465,6 +465,12 @@ describe('DocsService', () => {
 
       const result = await docsService.getText({ documentId: 'test-doc-id' });
 
+      expect(mockDocsAPI.documents.get).toHaveBeenCalledWith({
+        documentId: 'test-doc-id',
+        fields: `title,${TABS_FIELD_MASK}`,
+        includeTabsContent: true,
+        suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
+      });
       expect(result.content[0].text).toBe('Hello World\n');
     });
 

--- a/workspace-server/src/__tests__/services/DocsService.test.ts
+++ b/workspace-server/src/__tests__/services/DocsService.test.ts
@@ -12,7 +12,7 @@ import {
   beforeEach,
   afterEach,
 } from '@jest/globals';
-import { DocsService } from '../../services/DocsService';
+import { DocsService, TABS_FIELD_MASK } from '../../services/DocsService';
 import { AuthManager } from '../../auth/AuthManager';
 import { google } from 'googleapis';
 
@@ -845,8 +845,7 @@ describe('DocsService', () => {
 
       expect(mockDocsAPI.documents.get).toHaveBeenCalledWith({
         documentId: 'test-doc-id',
-        fields:
-          'tabs(tabProperties,documentTab(body,headers,footers,footnotes))',
+        fields: TABS_FIELD_MASK,
         includeTabsContent: true,
       });
 
@@ -923,8 +922,7 @@ describe('DocsService', () => {
 
       expect(mockDocsAPI.documents.get).toHaveBeenCalledWith({
         documentId: 'test-doc-id',
-        fields:
-          'tabs(tabProperties,documentTab(body,headers,footers,footnotes))',
+        fields: TABS_FIELD_MASK,
         includeTabsContent: true,
       });
 

--- a/workspace-server/src/__tests__/services/DocsService.test.ts
+++ b/workspace-server/src/__tests__/services/DocsService.test.ts
@@ -845,7 +845,8 @@ describe('DocsService', () => {
 
       expect(mockDocsAPI.documents.get).toHaveBeenCalledWith({
         documentId: 'test-doc-id',
-        fields: 'tabs',
+        fields:
+          'tabs(tabProperties,documentTab(body,headers,footers,footnotes))',
         includeTabsContent: true,
       });
 
@@ -922,7 +923,8 @@ describe('DocsService', () => {
 
       expect(mockDocsAPI.documents.get).toHaveBeenCalledWith({
         documentId: 'test-doc-id',
-        fields: 'tabs',
+        fields:
+          'tabs(tabProperties,documentTab(body,headers,footers,footnotes))',
         includeTabsContent: true,
       });
 

--- a/workspace-server/src/services/DocsService.ts
+++ b/workspace-server/src/services/DocsService.ts
@@ -11,6 +11,12 @@ import { extractDocId } from '../utils/IdUtils';
 import { gaxiosOptions } from '../utils/GaxiosConfig';
 import { extractDocumentId as validateAndExtractDocId } from '../utils/validation';
 
+// Field mask for documents.get when reading tab content. Selects only the
+// structural fields we use; broader masks like 'tabs' alone trigger
+// "comment-specific fields" errors when combined with includeTabsContent.
+export const TABS_FIELD_MASK =
+  'tabs(tabProperties,documentTab(body,headers,footers,footnotes))';
+
 interface BaseDocsSuggestion {
   text: string;
   startIndex?: number;
@@ -307,8 +313,7 @@ export class DocsService {
           // Discover the end index by reading the document (required for tabs)
           const res = await docs.documents.get({
             documentId: id,
-            fields:
-              'tabs(tabProperties,documentTab(body,headers,footers,footnotes))',
+            fields: TABS_FIELD_MASK,
             includeTabsContent: true,
           });
 
@@ -544,11 +549,10 @@ export class DocsService {
       const docs = await this.getDocsClient();
       const res = await docs.documents.get({
         documentId: id,
-        fields:
-          'title,tabs(tabProperties,documentTab(body,headers,footers,footnotes))',
+        fields: `title,${TABS_FIELD_MASK}`,
         includeTabsContent: true,
         suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
-      } as any);
+      });
 
       const docTitle = res.data.title;
       const tabs = this._flattenTabs(res.data.tabs || []);
@@ -739,8 +743,7 @@ export class DocsService {
       // Get the document to find where the text will be replaced
       const docBefore = await docs.documents.get({
         documentId: id,
-        fields:
-          'tabs(tabProperties,documentTab(body,headers,footers,footnotes))',
+        fields: TABS_FIELD_MASK,
         includeTabsContent: true,
       });
 

--- a/workspace-server/src/services/DocsService.ts
+++ b/workspace-server/src/services/DocsService.ts
@@ -307,7 +307,8 @@ export class DocsService {
           // Discover the end index by reading the document (required for tabs)
           const res = await docs.documents.get({
             documentId: id,
-            fields: 'tabs',
+            fields:
+              'tabs(tabProperties,documentTab(body,headers,footers,footnotes))',
             includeTabsContent: true,
           });
 
@@ -543,9 +544,11 @@ export class DocsService {
       const docs = await this.getDocsClient();
       const res = await docs.documents.get({
         documentId: id,
-        fields: 'title,tabs', // Request title and tabs (body is legacy and mutually exclusive with tabs in mask)
+        fields:
+          'title,tabs(tabProperties,documentTab(body,headers,footers,footnotes))',
         includeTabsContent: true,
-      });
+        suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS',
+      } as any);
 
       const docTitle = res.data.title;
       const tabs = this._flattenTabs(res.data.tabs || []);
@@ -736,7 +739,8 @@ export class DocsService {
       // Get the document to find where the text will be replaced
       const docBefore = await docs.documents.get({
         documentId: id,
-        fields: 'tabs',
+        fields:
+          'tabs(tabProperties,documentTab(body,headers,footers,footnotes))',
         includeTabsContent: true,
       });
 


### PR DESCRIPTION
This PR fixes a "comment-specific fields" error in `docs.getText` and tightens the `documents.get` calls in DocsService.

## Changes

1. **Refine the tabs field mask** from the broad `'tabs'` (or `'title,tabs'`) to a specific selection — `tabs(tabProperties,documentTab(body,headers,footers,footnotes))` — so it doesn't trigger internal API conflicts when combined with `includeTabsContent: true`. Applied at all three `documents.get` call sites in `DocsService.ts`, extracted to a single exported `TABS_FIELD_MASK` constant.
2. **Add `suggestionsViewMode: 'PREVIEW_WITHOUT_SUGGESTIONS'`** to the `getText` call so unaccepted suggestion markup doesn't leak into the extracted plain text.
3. **Update SKILL.md** to point users at `drive.getComments` instead of the (non-existent) `docs.getComments`.

## Tests

- Existing `replaceText` tests updated to reference the new `TABS_FIELD_MASK` constant.
- New assertion in the first `getText` test pinning the refined `documents.get` args (field mask + `suggestionsViewMode`) so future regressions are caught at PR time rather than only via API errors against real Docs.

## Drive-by: unbreak `print-scopes.ts` under TS 6

Rolled in here because it's blocking CI on `main` itself after #344 (TS 6 bump) and #347 (drift-guard test) landed in the same window:

- TS 6 became stricter about implicit `rootDir`. ts-node compiling `scripts/print-scopes.ts` against the root tsconfig (which only includes `workspace-server/src/`) failed with TS5011 — the file is outside the included tree, so TS couldn't infer rootDir.
- Added a small `scripts/tsconfig.json` with explicit `rootDir: ".."`, and pass `--project scripts/tsconfig.json` from both call sites (the drift-guard test and `setup-gcp.sh`).

This unblocks `main`'s CI as a side effect of merging this PR.