### PR TITLE
chore(release): v0.0.8

### DIFF
--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,11 +1,13 @@
 {
   "name": "google-workspace",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "contextFileName": "workspace-server${/}WORKSPACE-Context.md",
   "mcpServers": {
     "google-workspace": {
       "command": "node",
-      "args": ["scripts${/}start.js"],
+      "args": [
+        "scripts${/}start.js"
+      ],
       "cwd": "${extensionPath}"
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gemini-workspace-extension",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "Google Workspace Server Extension",
   "private": true,
   "bin": {

--- a/workspace-server/package.json
+++ b/workspace-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "workspace-server",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## Summary
- Bumps version to 0.0.8 in `package.json`, `workspace-server/package.json`, and `gemini-extension.json`.
- Cuts a release primarily to ship #349 (`fix(docs): resolve docs.getText API errors`).

## Changes since v0.0.7
- fix(docs): resolve docs.getText API errors (#349)
- fix(features): single source of truth for OAuth scopes; dedup read scopes (#347)
- refactor(calendar): moving validation logic outside of service (#316)
- Dependabot bumps (typescript 5.9.3 → 6.0.3, vite, hono, axios, protobufjs, etc.)

Once merged, tag `v0.0.8` on the merge commit to trigger `.github/workflows/release.yml`, which builds the platform tarballs and publishes the GitHub release.

## Test plan
- [x] CI passes on this branch
- [ ] After merge: tag `v0.0.8`, push tag, verify the release workflow produces linux/darwin/win32 tarballs and a GitHub release