### PR TITLE
fix(calendar): include attachments in listEvents field mask

### DIFF
--- a/workspace-server/src/__tests__/services/CalendarService.test.ts
+++ b/workspace-server/src/__tests__/services/CalendarService.test.ts
@@ -515,7 +515,9 @@ describe('CalendarService', () => {
       expect(callArgs.fields).toContain('attachments(');
 
       const returned = JSON.parse(result.content[0].text);
-      expect(returned[0].attachments[0].fileId).toBe('example-attachment-file-id');
+      expect(returned[0].attachments[0].fileId).toBe(
+        'example-attachment-file-id',
+      );
     });
 
     it('should list events with a default timeMax', async () => {

--- a/workspace-server/src/__tests__/services/CalendarService.test.ts
+++ b/workspace-server/src/__tests__/services/CalendarService.test.ts
@@ -429,7 +429,7 @@ describe('CalendarService', () => {
         timeMax: '2024-01-16T00:00:00Z',
         singleEvents: true,
         fields:
-          'items(id,summary,start,end,description,htmlLink,attendees,status,eventType,focusTimeProperties,outOfOfficeProperties,workingLocationProperties)',
+          'items(id,summary,start,end,description,htmlLink,attendees,status,eventType,focusTimeProperties,outOfOfficeProperties,workingLocationProperties,attachments(fileId,fileUrl,title,mimeType,iconLink))',
       });
 
       expect(JSON.parse(result.content[0].text)).toEqual(mockEvents);
@@ -471,10 +471,51 @@ describe('CalendarService', () => {
         timeMax: '2024-01-16T00:00:00Z',
         singleEvents: true,
         fields:
-          'items(id,summary,start,end,description,htmlLink,attendees,status,eventType,focusTimeProperties,outOfOfficeProperties,workingLocationProperties)',
+          'items(id,summary,start,end,description,htmlLink,attendees,status,eventType,focusTimeProperties,outOfOfficeProperties,workingLocationProperties,attachments(fileId,fileUrl,title,mimeType,iconLink))',
       });
 
       expect(JSON.parse(result.content[0].text)).toEqual(mockEvents);
+    });
+
+    it('should request native attachments and pass them through', async () => {
+      // listEvents previously dropped attachments even though getEvent returns
+      // them (no field mask) and createEvent/updateEvent fully support them.
+      // The events.list field mask must include attachments(...) so callers can
+      // see files attached to invites, and the payload must survive.
+      const mockEvents = [
+        {
+          id: 'event1',
+          summary: 'Team Sync',
+          start: { dateTime: '2024-01-15T09:00:00Z' },
+          end: { dateTime: '2024-01-15T10:00:00Z' },
+          status: 'confirmed',
+          attachments: [
+            {
+              fileId: 'example-attachment-file-id',
+              fileUrl:
+                'https://docs.google.com/presentation/d/example-attachment-file-id/edit',
+              title: 'Agenda Slides',
+              mimeType: 'application/vnd.google-apps.presentation',
+            },
+          ],
+        },
+      ];
+
+      mockCalendarAPI.events.list.mockResolvedValue({
+        data: { items: mockEvents },
+      });
+
+      const result = await calendarService.listEvents({
+        calendarId: 'primary',
+        timeMin: '2024-01-15T00:00:00Z',
+        timeMax: '2024-01-16T00:00:00Z',
+      });
+
+      const callArgs = mockCalendarAPI.events.list.mock.calls[0][0];
+      expect(callArgs.fields).toContain('attachments(');
+
+      const returned = JSON.parse(result.content[0].text);
+      expect(returned[0].attachments[0].fileId).toBe('example-attachment-file-id');
     });
 
     it('should list events with a default timeMax', async () => {

--- a/workspace-server/src/services/CalendarService.ts
+++ b/workspace-server/src/services/CalendarService.ts
@@ -490,7 +490,7 @@ export class CalendarService {
         timeMax,
         singleEvents: true,
         fields:
-          'items(id,summary,start,end,description,htmlLink,attendees,status,eventType,focusTimeProperties,outOfOfficeProperties,workingLocationProperties)',
+          'items(id,summary,start,end,description,htmlLink,attendees,status,eventType,focusTimeProperties,outOfOfficeProperties,workingLocationProperties,attachments(fileId,fileUrl,title,mimeType,iconLink))',
       };
       if (eventTypes && eventTypes.length > 0) {
         listParams.eventTypes = eventTypes;


### PR DESCRIPTION
## What

`listEvents` requests an explicit `fields` mask, and that mask omitted `attachments`. Because `events.list` only returns fields named in the mask, native event attachments were silently dropped from every `listEvents` result.

This adds `attachments(fileId,fileUrl,title,mimeType,iconLink)` to the mask.

## Why this is a consistency fix, not a new feature

Every *other* calendar method in `CalendarService` already exposes/handles attachments — `listEvents` was the lone exception:

- **`getEvent`** calls `events.get` with **no field mask**, so it already returns attachments.
- **`createEvent` / `updateEvent`** fully support attachments via the `EventAttachment` interface and `applyMeetAndAttachments` (`supportsAttachments`).

So a caller can create an event with an attachment and read it back via `getEvent`, but the same attachment vanishes when the event is fetched through `listEvents`. This change aligns `listEvents` with the rest of the service.

Note: reading attachments needs **no** `supportsAttachments` parameter — that flag is write-only (insert/update/patch). Adding the field to the read mask is sufficient.

## Impact

- Purely additive to the `fields` mask; no change to any existing field or to request/response shapes beyond the new `attachments` array.
- Slightly larger `listEvents` payloads when events carry attachments.

## Testing

- New unit test: asserts the `events.list` field mask includes `attachments(` and that an attachment's `fileId` survives into the tool payload.
- Updated the two existing field-mask assertions to include the new field.
- Full suite green: **512 passed, 28 suites**.
