### PR TITLE
feat: add attachment support to gmail.createDraft tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,10 @@ commit_message.txt
 # Release directory
 release/
 
+# Configuration and Local Settings
+.mcp.json
+.claude/
+
 # VitePress
 docs/.vitepress/dist
 docs/.vitepress/cache

--- a/workspace-server/src/__tests__/services/GmailService.test.ts
+++ b/workspace-server/src/__tests__/services/GmailService.test.ts
@@ -1339,8 +1339,137 @@ describe('GmailService', () => {
       });
 
       const response = JSON.parse(result.content[0].text);
+      // Bare errno is wrapped with the failing path so the error identifies
+      // which attachment could not be read
+      expect(response.error).toContain(
+        'Could not read attachment file /tmp/missing.pdf',
+      );
       expect(response.error).toContain('ENOENT');
       expect(mockGmailAPI.users.drafts.create).not.toHaveBeenCalled();
+    });
+
+    it('should surface fs.stat failures with a descriptive error and not call the Gmail API', async () => {
+      (fs.stat as any).mockRejectedValue(
+        new Error('EACCES: permission denied'),
+      );
+
+      const result = await gmailService.createDraft({
+        to: 'a@example.com',
+        subject: 'S',
+        body: 'B',
+        attachments: [{ filePath: '/tmp/locked.pdf' }],
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain(
+        'Could not access attachment file /tmp/locked.pdf',
+      );
+      expect(response.error).toContain('EACCES');
+      expect(fs.readFile).not.toHaveBeenCalled();
+      expect(mockGmailAPI.users.drafts.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject when the combined size of multiple attachments exceeds the limit', async () => {
+      // Each file is well under the 18MB cap; only their sum exceeds it.
+      (fs.stat as any).mockResolvedValue({
+        isFile: () => true,
+        size: 10 * 1024 * 1024, // 10MB each
+      });
+
+      const result = await gmailService.createDraft({
+        to: 'recipient@example.com',
+        subject: 'Combined Too Large',
+        body: 'Body',
+        attachments: [{ filePath: '/tmp/a.zip' }, { filePath: '/tmp/b.zip' }],
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('20.00MB');
+      expect(response.error).toContain('exceeds the maximum allowed limit');
+      expect(fs.readFile).not.toHaveBeenCalled();
+      expect(mockGmailAPI.users.drafts.create).not.toHaveBeenCalled();
+    });
+
+    it('should attach multiple files and pass each to the MIME builder', async () => {
+      mockGmailAPI.users.drafts.create.mockResolvedValue({
+        data: {
+          id: 'd-multi',
+          message: { id: 'm-multi', threadId: null, labelIds: [] },
+        },
+      });
+      const bufA = Buffer.from('first file');
+      const bufB = Buffer.from('second file');
+      (fs.readFile as any).mockImplementation(async (p: string) =>
+        p === '/tmp/a.pdf' ? bufA : bufB,
+      );
+
+      await gmailService.createDraft({
+        to: 'a@example.com',
+        subject: 'S',
+        body: 'B',
+        attachments: [{ filePath: '/tmp/a.pdf' }, { filePath: '/tmp/b.txt' }],
+      });
+
+      expect(
+        MimeHelper.createMimeMessageWithAttachments as jest.Mock,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: [
+            {
+              filename: 'a.pdf',
+              content: bufA,
+              contentType: 'application/pdf',
+            },
+            { filename: 'b.txt', content: bufB, contentType: 'text/plain' },
+          ],
+        }),
+      );
+    });
+
+    it('should enforce the size cap against bytes actually read (stat/read TOCTOU)', async () => {
+      // stat reports a small size, but the file grew before readFile ran
+      (fs.stat as any).mockResolvedValue({ isFile: () => true, size: 1024 });
+      (fs.readFile as any).mockResolvedValue(
+        Buffer.alloc(18 * 1024 * 1024 + 1),
+      );
+
+      const result = await gmailService.createDraft({
+        to: 'a@example.com',
+        subject: 'S',
+        body: 'B',
+        attachments: [{ filePath: '/tmp/grew.bin' }],
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('exceeds the maximum allowed limit');
+      expect(mockGmailAPI.users.drafts.create).not.toHaveBeenCalled();
+    });
+
+    it('should reject an invalid replyTo address', async () => {
+      const result = await gmailService.createDraft({
+        to: 'valid@example.com',
+        subject: 'S',
+        body: 'B',
+        replyTo: 'not-an-email',
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toBe('Invalid email address format');
+      expect(MimeHelper.createMimeMessage).not.toHaveBeenCalled();
+    });
+
+    it('should reject invalid cc and bcc addresses', async () => {
+      const result = await gmailService.createDraft({
+        to: 'valid@example.com',
+        subject: 'S',
+        body: 'B',
+        cc: ['ok@example.com', 'bad-cc'],
+        bcc: 'bad-bcc',
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toBe('Invalid email address format');
+      expect(MimeHelper.createMimeMessage).not.toHaveBeenCalled();
     });
 
     it('should use createMimeMessage (not WithAttachments) when attachments array is empty', async () => {

--- a/workspace-server/src/__tests__/services/GmailService.test.ts
+++ b/workspace-server/src/__tests__/services/GmailService.test.ts
@@ -20,7 +20,7 @@ import { google } from 'googleapis';
 
 // Mock the modules
 jest.mock('googleapis');
-jest.mock('fs/promises');
+jest.mock('node:fs/promises');
 jest.mock('../../utils/logger');
 jest.mock('../../utils/MimeHelper');
 
@@ -760,6 +760,25 @@ describe('GmailService', () => {
       expect(response.labelIds).toEqual(['SENT']);
     });
 
+    it('should support replyTo in email', async () => {
+      mockGmailAPI.users.messages.send.mockResolvedValue({
+        data: { id: 'sent-msg-reply' },
+      });
+
+      await gmailService.send({
+        to: 'recipient@example.com',
+        subject: 'Test Subject',
+        body: 'Test Body',
+        replyTo: 'support@example.com',
+      });
+
+      expect(MimeHelper.createMimeMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          replyTo: 'support@example.com',
+        }),
+      );
+    });
+
     it('should send email with multiple recipients', async () => {
       mockGmailAPI.users.messages.send.mockResolvedValue({
         data: { id: 'sent-msg-2' },
@@ -822,6 +841,13 @@ describe('GmailService', () => {
       (MimeHelper.createMimeMessage as jest.Mock) = jest
         .fn()
         .mockReturnValue('base64encodedmessage');
+      (MimeHelper.createMimeMessageWithAttachments as jest.Mock) = jest
+        .fn()
+        .mockReturnValue('base64encodedmessage-with-attachments');
+      (fs.stat as any).mockResolvedValue({
+        isFile: () => true,
+        size: 1024,
+      });
     });
 
     it('should create a draft email', async () => {
@@ -843,6 +869,18 @@ describe('GmailService', () => {
         body: 'Draft Body',
       });
 
+      expect(MimeHelper.createMimeMessage).toHaveBeenCalledWith({
+        to: 'recipient@example.com',
+        subject: 'Draft Subject',
+        body: 'Draft Body',
+        cc: undefined,
+        bcc: undefined,
+        replyTo: undefined,
+        isHtml: false,
+        inReplyTo: undefined,
+        references: undefined,
+      });
+
       expect(mockGmailAPI.users.drafts.create).toHaveBeenCalledWith({
         userId: 'me',
         requestBody: {
@@ -857,6 +895,72 @@ describe('GmailService', () => {
       expect(response.id).toBe('draft1');
       expect(response.message.id).toBe('msg1');
       expect(response.message.threadId).toBe('thread1');
+    });
+
+    it('should support replyTo in draft email', async () => {
+      mockGmailAPI.users.drafts.create.mockResolvedValue({
+        data: { id: 'd-reply', message: { id: 'm-reply' } },
+      });
+
+      await gmailService.createDraft({
+        to: 'recipient@example.com',
+        subject: 'Draft Subject',
+        body: 'Draft Body',
+        replyTo: 'support@example.com',
+      });
+
+      expect(MimeHelper.createMimeMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          replyTo: 'support@example.com',
+        }),
+      );
+    });
+
+    it('should reject invalid recipient email addresses', async () => {
+      const result = await gmailService.createDraft({
+        to: 'not-an-email',
+        subject: 'Draft Subject',
+        body: 'Draft Body',
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toBe('Invalid email address format');
+      expect(MimeHelper.createMimeMessage).not.toHaveBeenCalled();
+    });
+
+    it('should enforce maximum total attachment size', async () => {
+      (fs.stat as any).mockResolvedValue({
+        isFile: () => true,
+        size: 30 * 1024 * 1024, // 30MB
+      });
+
+      const result = await gmailService.createDraft({
+        to: 'recipient@example.com',
+        subject: 'Too Large',
+        body: 'Body',
+        attachments: [{ filePath: '/tmp/huge.zip' }],
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('exceeds the maximum allowed limit');
+      expect(fs.readFile).not.toHaveBeenCalled();
+    });
+
+    it('should validate attachment path is a file', async () => {
+      (fs.stat as any).mockResolvedValue({
+        isFile: () => false,
+        size: 0,
+      });
+
+      const result = await gmailService.createDraft({
+        to: 'recipient@example.com',
+        subject: 'Not a file',
+        body: 'Body',
+        attachments: [{ filePath: '/tmp/directory' }],
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('path is not a file');
     });
 
     it('should handle draft creation errors', async () => {
@@ -993,6 +1097,228 @@ describe('GmailService', () => {
 
       const response = JSON.parse(result.content[0].text);
       expect(response.status).toBe('draft_created');
+    });
+
+    it('should create a draft with attachments using createMimeMessageWithAttachments', async () => {
+      const mockDraft = {
+        id: 'draft-attach-1',
+        message: { id: 'msg-attach-1', threadId: null, labelIds: ['DRAFT'] },
+      };
+      mockGmailAPI.users.drafts.create.mockResolvedValue({ data: mockDraft });
+
+      const mockFileBuffer = Buffer.from('PDF content');
+      (fs.readFile as any).mockResolvedValue(mockFileBuffer);
+
+      const result = await gmailService.createDraft({
+        to: 'recipient@example.com',
+        subject: 'Draft with Attachment',
+        body: 'See attached.',
+        attachments: [{ filePath: '/tmp/report.pdf', mimeType: 'application/pdf' }],
+      });
+
+      expect((fs.readFile as any).mock.calls[0][0]).toBe('/tmp/report.pdf');
+      expect(
+        MimeHelper.createMimeMessageWithAttachments as jest.Mock,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: [
+            {
+              filename: 'report.pdf',
+              content: mockFileBuffer,
+              contentType: 'application/pdf',
+            },
+          ],
+          inReplyTo: undefined,
+          references: undefined,
+        }),
+      );
+      expect(MimeHelper.createMimeMessage).not.toHaveBeenCalled();
+
+      expect(mockGmailAPI.users.drafts.create).toHaveBeenCalledWith({
+        userId: 'me',
+        requestBody: { message: { raw: 'base64encodedmessage-with-attachments' } },
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.status).toBe('draft_created');
+      expect(response.id).toBe('draft-attach-1');
+    });
+
+    it('should use filename override when provided', async () => {
+      mockGmailAPI.users.drafts.create.mockResolvedValue({
+        data: { id: 'draft2', message: { id: 'msg2', threadId: null, labelIds: [] } },
+      });
+      (fs.readFile as any).mockResolvedValue(Buffer.from('data'));
+
+      await gmailService.createDraft({
+        to: 'a@example.com',
+        subject: 'S',
+        body: 'B',
+        attachments: [{ filePath: '/tmp/123abc.tmp', filename: 'custom-name.pdf' }],
+      });
+
+      expect(
+        MimeHelper.createMimeMessageWithAttachments as jest.Mock,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: expect.arrayContaining([
+            expect.objectContaining({ filename: 'custom-name.pdf' }),
+          ]),
+        }),
+      );
+    });
+
+    it('should infer MIME type from extension when mimeType not provided', async () => {
+      mockGmailAPI.users.drafts.create.mockResolvedValue({
+        data: { id: 'd3', message: { id: 'm3', threadId: null, labelIds: [] } },
+      });
+      (fs.readFile as any).mockResolvedValue(Buffer.from('data'));
+
+      await gmailService.createDraft({
+        to: 'a@example.com',
+        subject: 'S',
+        body: 'B',
+        attachments: [{ filePath: '/tmp/report.xlsx' }],
+      });
+
+      expect(
+        MimeHelper.createMimeMessageWithAttachments as jest.Mock,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: expect.arrayContaining([
+            expect.objectContaining({
+              contentType:
+                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+            }),
+          ]),
+        }),
+      );
+    });
+
+    it('should fall back to application/octet-stream for unknown extension', async () => {
+      mockGmailAPI.users.drafts.create.mockResolvedValue({
+        data: { id: 'd4', message: { id: 'm4', threadId: null, labelIds: [] } },
+      });
+      (fs.readFile as any).mockResolvedValue(Buffer.from('data'));
+
+      await gmailService.createDraft({
+        to: 'a@example.com',
+        subject: 'S',
+        body: 'B',
+        attachments: [{ filePath: '/tmp/mystery.xyz' }],
+      });
+
+      expect(
+        MimeHelper.createMimeMessageWithAttachments as jest.Mock,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: expect.arrayContaining([
+            expect.objectContaining({ contentType: 'application/octet-stream' }),
+          ]),
+        }),
+      );
+    });
+
+    it('should pass inReplyTo and references to createMimeMessageWithAttachments for threaded draft with attachments', async () => {
+      const mockDraft = {
+        id: 'draft-thread-attach',
+        message: { id: 'msg-ta', threadId: 'thread1', labelIds: ['DRAFT'] },
+      };
+      mockGmailAPI.users.threads.get.mockResolvedValue({
+        data: {
+          messages: [
+            {
+              payload: {
+                headers: [
+                  { name: 'Message-ID', value: '<orig@mail.example.com>' },
+                  { name: 'References', value: '<prev@mail.example.com>' },
+                ],
+              },
+            },
+          ],
+        },
+      });
+      mockGmailAPI.users.drafts.create.mockResolvedValue({ data: mockDraft });
+      (fs.readFile as any).mockResolvedValue(Buffer.from('data'));
+
+      const result = await gmailService.createDraft({
+        to: 'b@example.com',
+        subject: 'Re: Attached Reply',
+        body: 'See file.',
+        threadId: 'thread1',
+        attachments: [{ filePath: '/tmp/file.pdf' }],
+      });
+
+      expect(
+        MimeHelper.createMimeMessageWithAttachments as jest.Mock,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inReplyTo: '<orig@mail.example.com>',
+          references: '<prev@mail.example.com> <orig@mail.example.com>',
+        }),
+      );
+      expect(mockGmailAPI.users.drafts.create).toHaveBeenCalledWith({
+        userId: 'me',
+        requestBody: {
+          message: {
+            raw: 'base64encodedmessage-with-attachments',
+            threadId: 'thread1',
+          },
+        },
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.status).toBe('draft_created');
+    });
+
+    it('should reject a relative filePath and return error without calling Gmail API', async () => {
+      const result = await gmailService.createDraft({
+        to: 'a@example.com',
+        subject: 'S',
+        body: 'B',
+        attachments: [{ filePath: 'relative/path/file.pdf' }],
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('must be an absolute path');
+      expect(mockGmailAPI.users.drafts.create).not.toHaveBeenCalled();
+      expect((fs.readFile as any).mock.calls).toHaveLength(0);
+    });
+
+    it('should handle readFile failure (file not found) gracefully', async () => {
+      (fs.readFile as any).mockRejectedValue(
+        new Error('ENOENT: no such file'),
+      );
+
+      const result = await gmailService.createDraft({
+        to: 'a@example.com',
+        subject: 'S',
+        body: 'B',
+        attachments: [{ filePath: '/tmp/missing.pdf' }],
+      });
+
+      const response = JSON.parse(result.content[0].text);
+      expect(response.error).toContain('ENOENT');
+      expect(mockGmailAPI.users.drafts.create).not.toHaveBeenCalled();
+    });
+
+    it('should use createMimeMessage (not WithAttachments) when attachments array is empty', async () => {
+      mockGmailAPI.users.drafts.create.mockResolvedValue({
+        data: { id: 'd5', message: { id: 'm5', threadId: null, labelIds: [] } },
+      });
+
+      await gmailService.createDraft({
+        to: 'a@example.com',
+        subject: 'S',
+        body: 'B',
+        attachments: [],
+      });
+
+      expect(MimeHelper.createMimeMessage).toHaveBeenCalled();
+      expect(
+        MimeHelper.createMimeMessageWithAttachments as jest.Mock,
+      ).not.toHaveBeenCalled();
+      expect((fs.readFile as any).mock.calls).toHaveLength(0);
     });
   });
 

--- a/workspace-server/src/__tests__/services/GmailService.test.ts
+++ b/workspace-server/src/__tests__/services/GmailService.test.ts
@@ -1113,7 +1113,9 @@ describe('GmailService', () => {
         to: 'recipient@example.com',
         subject: 'Draft with Attachment',
         body: 'See attached.',
-        attachments: [{ filePath: '/tmp/report.pdf', mimeType: 'application/pdf' }],
+        attachments: [
+          { filePath: '/tmp/report.pdf', mimeType: 'application/pdf' },
+        ],
       });
 
       expect((fs.readFile as any).mock.calls[0][0]).toBe('/tmp/report.pdf');
@@ -1136,7 +1138,9 @@ describe('GmailService', () => {
 
       expect(mockGmailAPI.users.drafts.create).toHaveBeenCalledWith({
         userId: 'me',
-        requestBody: { message: { raw: 'base64encodedmessage-with-attachments' } },
+        requestBody: {
+          message: { raw: 'base64encodedmessage-with-attachments' },
+        },
       });
 
       const response = JSON.parse(result.content[0].text);
@@ -1146,7 +1150,10 @@ describe('GmailService', () => {
 
     it('should use filename override when provided', async () => {
       mockGmailAPI.users.drafts.create.mockResolvedValue({
-        data: { id: 'draft2', message: { id: 'msg2', threadId: null, labelIds: [] } },
+        data: {
+          id: 'draft2',
+          message: { id: 'msg2', threadId: null, labelIds: [] },
+        },
       });
       (fs.readFile as any).mockResolvedValue(Buffer.from('data'));
 
@@ -1154,7 +1161,9 @@ describe('GmailService', () => {
         to: 'a@example.com',
         subject: 'S',
         body: 'B',
-        attachments: [{ filePath: '/tmp/123abc.tmp', filename: 'custom-name.pdf' }],
+        attachments: [
+          { filePath: '/tmp/123abc.tmp', filename: 'custom-name.pdf' },
+        ],
       });
 
       expect(
@@ -1163,6 +1172,38 @@ describe('GmailService', () => {
         expect.objectContaining({
           attachments: expect.arrayContaining([
             expect.objectContaining({ filename: 'custom-name.pdf' }),
+          ]),
+        }),
+      );
+    });
+
+    it('should fall back to defaults when filename or mimeType are empty strings', async () => {
+      mockGmailAPI.users.drafts.create.mockResolvedValue({
+        data: {
+          id: 'draft-empty',
+          message: { id: 'msg-empty', threadId: null, labelIds: [] },
+        },
+      });
+      (fs.readFile as any).mockResolvedValue(Buffer.from('data'));
+
+      await gmailService.createDraft({
+        to: 'a@example.com',
+        subject: 'S',
+        body: 'B',
+        attachments: [
+          { filePath: '/tmp/report.pdf', filename: '', mimeType: '' },
+        ],
+      });
+
+      expect(
+        MimeHelper.createMimeMessageWithAttachments as jest.Mock,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          attachments: expect.arrayContaining([
+            expect.objectContaining({
+              filename: 'report.pdf',
+              contentType: 'application/pdf',
+            }),
           ]),
         }),
       );
@@ -1213,7 +1254,9 @@ describe('GmailService', () => {
       ).toHaveBeenCalledWith(
         expect.objectContaining({
           attachments: expect.arrayContaining([
-            expect.objectContaining({ contentType: 'application/octet-stream' }),
+            expect.objectContaining({
+              contentType: 'application/octet-stream',
+            }),
           ]),
         }),
       );
@@ -1286,9 +1329,7 @@ describe('GmailService', () => {
     });
 
     it('should handle readFile failure (file not found) gracefully', async () => {
-      (fs.readFile as any).mockRejectedValue(
-        new Error('ENOENT: no such file'),
-      );
+      (fs.readFile as any).mockRejectedValue(new Error('ENOENT: no such file'));
 
       const result = await gmailService.createDraft({
         to: 'a@example.com',

--- a/workspace-server/src/__tests__/utils/MimeHelper.test.ts
+++ b/workspace-server/src/__tests__/utils/MimeHelper.test.ts
@@ -365,6 +365,74 @@ describe('MimeHelper', () => {
       expect(boundary2Match).toBeTruthy();
       expect(boundary1Match![1]).not.toBe(boundary2Match![1]);
     });
+
+    it('should include In-Reply-To and References headers when provided with attachments', () => {
+      const messageId = '<original@mail.example.com>';
+      const refs = '<earlier@mail.example.com> <original@mail.example.com>';
+      const attachments = [
+        {
+          filename: 'test.txt',
+          content: Buffer.from('hello'),
+          contentType: 'text/plain',
+        },
+      ];
+
+      const encoded = MimeHelper.createMimeMessageWithAttachments({
+        to: 'recipient@example.com',
+        subject: 'Re: Test',
+        body: 'Reply with attachment',
+        inReplyTo: messageId,
+        references: refs,
+        attachments,
+      });
+
+      const decoded = MimeHelper.decodeBase64Url(encoded);
+
+      expect(decoded).toContain(`In-Reply-To: ${messageId}`);
+      expect(decoded).toContain(`References: ${refs}`);
+      // Still multipart
+      expect(decoded).toContain('Content-Type: multipart/mixed; boundary=');
+    });
+
+    it('should include In-Reply-To and References headers when no attachments (fallback path)', () => {
+      const messageId = '<original@mail.example.com>';
+
+      const encoded = MimeHelper.createMimeMessageWithAttachments({
+        to: 'recipient@example.com',
+        subject: 'Re: Test',
+        body: 'Reply without attachment',
+        inReplyTo: messageId,
+        references: messageId,
+        // no attachments — exercises the createMimeMessage fallback
+      });
+
+      const decoded = MimeHelper.decodeBase64Url(encoded);
+
+      expect(decoded).toContain(`In-Reply-To: ${messageId}`);
+      expect(decoded).toContain(`References: ${messageId}`);
+    });
+
+    it('should not include In-Reply-To or References in multipart message when not provided', () => {
+      const attachments = [
+        {
+          filename: 'file.pdf',
+          content: Buffer.from('data'),
+          contentType: 'application/pdf',
+        },
+      ];
+
+      const encoded = MimeHelper.createMimeMessageWithAttachments({
+        to: 'recipient@example.com',
+        subject: 'New Draft',
+        body: 'Body',
+        attachments,
+      });
+
+      const decoded = MimeHelper.decodeBase64Url(encoded);
+
+      expect(decoded).not.toContain('In-Reply-To:');
+      expect(decoded).not.toContain('References:');
+    });
   });
 
   describe('decodeBase64Url', () => {

--- a/workspace-server/src/__tests__/utils/MimeHelper.test.ts
+++ b/workspace-server/src/__tests__/utils/MimeHelper.test.ts
@@ -140,6 +140,28 @@ describe('MimeHelper', () => {
       expect(decoded).toContain(`References: ${messageId}`);
     });
 
+    it('should sanitize In-Reply-To and References headers in simple messages', () => {
+      const encoded = MimeHelper.createMimeMessage({
+        to: 'recipient@example.com',
+        subject: 'Re: Test',
+        body: 'Body',
+        inReplyTo: '<orig@example.com>\r\nX-Injected: true',
+        references: '<a@example.com>\r\nX-Also-Injected: true',
+      });
+
+      const decoded = MimeHelper.decodeBase64Url(encoded);
+
+      // CR/LF stripped, so injected text cannot start a new header line
+      expect(decoded).not.toContain('\r\nX-Injected:');
+      expect(decoded).not.toContain('\r\nX-Also-Injected:');
+      expect(decoded).toContain(
+        'In-Reply-To: <orig@example.com>X-Injected: true',
+      );
+      expect(decoded).toContain(
+        'References: <a@example.com>X-Also-Injected: true',
+      );
+    });
+
     it('should not include In-Reply-To or References headers when not provided', () => {
       const encoded = MimeHelper.createMimeMessage({
         to: 'recipient@example.com',
@@ -271,6 +293,64 @@ describe('MimeHelper', () => {
       );
       expect(decoded).toContain(
         'Content-Type: application/pdfX-Also-Injected: true',
+      );
+    });
+
+    it('should escape backslashes before quotes in attachment filenames', () => {
+      const attachments = [
+        {
+          // Raw filename: dir\file"name.txt
+          filename: 'dir\\file"name.txt',
+          content: Buffer.from('content'),
+          contentType: 'text/plain',
+        },
+      ];
+
+      const encoded = MimeHelper.createMimeMessageWithAttachments({
+        to: 'recipient@example.com',
+        subject: 'Backslash Test',
+        body: 'Message',
+        attachments,
+      });
+
+      const decoded = MimeHelper.decodeBase64Url(encoded);
+
+      // Backslashes must be doubled BEFORE quotes are escaped, so a literal
+      // backslash can never pair with an escaped quote to re-terminate the
+      // filename parameter. Expected on the wire: dir\\file\"name.txt
+      expect(decoded).toContain(
+        'Content-Disposition: attachment; filename="dir\\\\file\\"name.txt"',
+      );
+    });
+
+    it('should sanitize In-Reply-To and References headers in multipart messages', () => {
+      const attachments = [
+        {
+          filename: 'f.txt',
+          content: Buffer.from('x'),
+          contentType: 'text/plain',
+        },
+      ];
+
+      const encoded = MimeHelper.createMimeMessageWithAttachments({
+        to: 'recipient@example.com',
+        subject: 'Re: Test',
+        body: 'Body',
+        inReplyTo: '<orig@example.com>\r\nX-Injected: true',
+        references: '<a@example.com>\r\nX-Also-Injected: true',
+        attachments,
+      });
+
+      const decoded = MimeHelper.decodeBase64Url(encoded);
+
+      // CR/LF stripped, so injected text cannot start a new header line
+      expect(decoded).not.toContain('\r\nX-Injected:');
+      expect(decoded).not.toContain('\r\nX-Also-Injected:');
+      expect(decoded).toContain(
+        'In-Reply-To: <orig@example.com>X-Injected: true',
+      );
+      expect(decoded).toContain(
+        'References: <a@example.com>X-Also-Injected: true',
       );
     });
 

--- a/workspace-server/src/__tests__/utils/MimeHelper.test.ts
+++ b/workspace-server/src/__tests__/utils/MimeHelper.test.ts
@@ -244,6 +244,36 @@ describe('MimeHelper', () => {
       expect(decoded).toContain('Content-Type: application/octet-stream');
     });
 
+    it('should sanitize attachment filenames to prevent MIME header injection', () => {
+      const attachments = [
+        {
+          filename: 'evil"\r\nX-Injected: true\r\n.pdf',
+          content: Buffer.from('content'),
+          contentType: 'application/pdf\r\nX-Also-Injected: true',
+        },
+      ];
+
+      const encoded = MimeHelper.createMimeMessageWithAttachments({
+        to: 'recipient@example.com',
+        subject: 'Injection Attempt',
+        body: 'Message',
+        attachments,
+      });
+
+      const decoded = MimeHelper.decodeBase64Url(encoded);
+
+      // CR/LF stripped, so injected text can never start a new header line
+      expect(decoded).not.toContain('\r\nX-Injected:');
+      expect(decoded).not.toContain('\r\nX-Also-Injected:');
+      // Quotes escaped, so the filename parameter cannot be terminated early
+      expect(decoded).toContain(
+        'Content-Disposition: attachment; filename="evil\\"X-Injected: true.pdf"',
+      );
+      expect(decoded).toContain(
+        'Content-Type: application/pdfX-Also-Injected: true',
+      );
+    });
+
     it('should properly format attachment content in 76-character lines', () => {
       const longContent = 'a'.repeat(200); // Long content that needs to be wrapped
       const attachments = [

--- a/workspace-server/src/__tests__/utils/validation.test.ts
+++ b/workspace-server/src/__tests__/utils/validation.test.ts
@@ -12,6 +12,7 @@ import {
   extractDocumentId,
   emailSchema,
   emailArraySchema,
+  gmailAttachmentSchema,
   searchQuerySchema,
   ValidationError,
 } from '../../utils/validation';
@@ -64,6 +65,36 @@ describe('Validation Utilities', () => {
         'invalid-email',
       ]);
       expect(result.success).toBe(false);
+    });
+  });
+
+  describe('Gmail Attachment Validation', () => {
+    it('should accept an absolute filePath with optional fields omitted', () => {
+      const result = gmailAttachmentSchema.safeParse({
+        filePath: '/tmp/report.pdf',
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('should reject a relative filePath', () => {
+      const result = gmailAttachmentSchema.safeParse({
+        filePath: 'relative/report.pdf',
+      });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.issues[0].message).toBe(
+          'filePath must be an absolute path',
+        );
+      }
+    });
+
+    it('should accept empty-string filename and mimeType (service falls back to defaults)', () => {
+      const result = gmailAttachmentSchema.safeParse({
+        filePath: '/tmp/report.pdf',
+        filename: '',
+        mimeType: '',
+      });
+      expect(result.success).toBe(true);
     });
   });
 

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -92,6 +92,10 @@ const emailComposeSchema = {
     .union([z.string(), z.array(z.string())])
     .optional()
     .describe('BCC recipient email address(es).'),
+  replyTo: z
+    .string()
+    .optional()
+    .describe('The email address to which replies should be sent.'),
   isHtml: z
     .boolean()
     .optional()
@@ -1298,6 +1302,32 @@ System labels that can be modified:
           .optional()
           .describe(
             'The thread ID to create the draft as a reply to. When provided, the draft will be linked to the existing thread with appropriate reply headers.',
+          ),
+        attachments: z
+          .array(
+            z.object({
+              filePath: z
+                .string()
+                .describe(
+                  'Absolute local filesystem path to the file to attach (e.g., "/Users/name/downloads/report.pdf"). Use gmail.downloadAttachment first to save an email attachment locally before referencing it here.',
+                ),
+              filename: z
+                .string()
+                .optional()
+                .describe(
+                  'Display name for the attachment in the email. Defaults to the filename portion of filePath.',
+                ),
+              mimeType: z
+                .string()
+                .optional()
+                .describe(
+                  'MIME type of the attachment (e.g., "application/pdf"). Inferred from the file extension when omitted; falls back to "application/octet-stream".',
+                ),
+            }),
+          )
+          .optional()
+          .describe(
+            'Files to attach to the draft. Each entry must reference an absolute local path. Download attachments first with gmail.downloadAttachment if needed.',
           ),
       },
     },

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -20,6 +20,7 @@ import { PeopleService } from './services/PeopleService';
 import { SlidesService } from './services/SlidesService';
 import { SheetsService } from './services/SheetsService';
 import { GMAIL_SEARCH_MAX_RESULTS } from './utils/constants';
+import { gmailAttachmentSchema } from './utils/validation';
 
 import { setLoggingEnabled, logToFile } from './utils/logger';
 import { applyToolNameNormalization } from './utils/tool-normalization';
@@ -1304,27 +1305,7 @@ System labels that can be modified:
             'The thread ID to create the draft as a reply to. When provided, the draft will be linked to the existing thread with appropriate reply headers.',
           ),
         attachments: z
-          .array(
-            z.object({
-              filePath: z
-                .string()
-                .describe(
-                  'Absolute local filesystem path to the file to attach (e.g., "/Users/name/downloads/report.pdf"). Use gmail.downloadAttachment first to save an email attachment locally before referencing it here.',
-                ),
-              filename: z
-                .string()
-                .optional()
-                .describe(
-                  'Display name for the attachment in the email. Defaults to the filename portion of filePath.',
-                ),
-              mimeType: z
-                .string()
-                .optional()
-                .describe(
-                  'MIME type of the attachment (e.g., "application/pdf"). Inferred from the file extension when omitted; falls back to "application/octet-stream".',
-                ),
-            }),
-          )
+          .array(gmailAttachmentSchema)
           .optional()
           .describe(
             'Files to attach to the draft. Each entry must reference an absolute local path. Download attachments first with gmail.downloadAttachment if needed.',

--- a/workspace-server/src/services/GmailService.ts
+++ b/workspace-server/src/services/GmailService.ts
@@ -25,8 +25,7 @@ const EXTENSION_MIME_MAP: Record<string, string> = {
   '.docx':
     'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
   '.xls': 'application/vnd.ms-excel',
-  '.xlsx':
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
   '.ppt': 'application/vnd.ms-powerpoint',
   '.pptx':
     'application/vnd.openxmlformats-officedocument.presentationml.presentation',
@@ -457,6 +456,44 @@ export class GmailService {
     }
   };
 
+  /**
+   * Validates recipient email addresses shared by send and createDraft.
+   * Returns a structured error response when validation fails, or null when
+   * all provided addresses are valid.
+   */
+  private validateEmailAddresses({
+    to,
+    cc,
+    bcc,
+    replyTo,
+  }: {
+    to: string | string[];
+    cc?: string | string[];
+    bcc?: string | string[];
+    replyTo?: string;
+  }) {
+    try {
+      emailArraySchema.parse(to);
+      if (cc) emailArraySchema.parse(cc);
+      if (bcc) emailArraySchema.parse(bcc);
+      if (replyTo) emailArraySchema.parse(replyTo);
+      return null;
+    } catch (error) {
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify({
+              error: 'Invalid email address format',
+              details:
+                error instanceof Error ? error.message : 'Validation failed',
+            }),
+          },
+        ],
+      };
+    }
+  }
+
   public send = async ({
     to,
     subject,
@@ -468,24 +505,14 @@ export class GmailService {
   }: SendEmailParams) => {
     try {
       // Validate email addresses
-      try {
-        emailArraySchema.parse(to);
-        if (cc) emailArraySchema.parse(cc);
-        if (bcc) emailArraySchema.parse(bcc);
-        if (replyTo) emailArraySchema.parse(replyTo);
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                error: 'Invalid email address format',
-                details:
-                  error instanceof Error ? error.message : 'Validation failed',
-              }),
-            },
-          ],
-        };
+      const validationError = this.validateEmailAddresses({
+        to,
+        cc,
+        bcc,
+        replyTo,
+      });
+      if (validationError) {
+        return validationError;
       }
 
       logToFile(`Sending email to: ${to}, subject: ${subject}`);
@@ -546,24 +573,14 @@ export class GmailService {
   }: CreateDraftParams) => {
     try {
       // Validate email addresses
-      try {
-        emailArraySchema.parse(to);
-        if (cc) emailArraySchema.parse(cc);
-        if (bcc) emailArraySchema.parse(bcc);
-        if (replyTo) emailArraySchema.parse(replyTo);
-      } catch (error) {
-        return {
-          content: [
-            {
-              type: 'text' as const,
-              text: JSON.stringify({
-                error: 'Invalid email address format',
-                details:
-                  error instanceof Error ? error.message : 'Validation failed',
-              }),
-            },
-          ],
-        };
+      const validationError = this.validateEmailAddresses({
+        to,
+        cc,
+        bcc,
+        replyTo,
+      });
+      if (validationError) {
+        return validationError;
       }
 
       logToFile(`Creating draft - to: ${to}, subject: ${subject}`);
@@ -619,19 +636,20 @@ export class GmailService {
               );
             }
 
+            let stats;
             try {
-              const stats = await fs.stat(att.filePath);
-              if (!stats.isFile()) {
-                throw new Error(
-                  `Attachment path is not a file: ${att.filePath}`,
-                );
-              }
-              return stats.size;
+              stats = await fs.stat(att.filePath);
             } catch (statError) {
               throw new Error(
                 `Could not access attachment file ${att.filePath}: ${statError instanceof Error ? statError.message : String(statError)}`,
               );
             }
+
+            if (!stats.isFile()) {
+              throw new Error(`Attachment path is not a file: ${att.filePath}`);
+            }
+
+            return stats.size;
           }),
         );
         const totalSize = attachmentSizes.reduce((sum, size) => sum + size, 0);

--- a/workspace-server/src/services/GmailService.ts
+++ b/workspace-server/src/services/GmailService.ts
@@ -18,6 +18,51 @@ import {
 import { gaxiosOptions } from '../utils/GaxiosConfig';
 import { emailArraySchema } from '../utils/validation';
 
+// Extension to MIME type map for common file types
+const EXTENSION_MIME_MAP: Record<string, string> = {
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx':
+    'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx':
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx':
+    'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.txt': 'text/plain',
+  '.csv': 'text/csv',
+  '.html': 'text/html',
+  '.htm': 'text/html',
+  '.json': 'application/json',
+  '.xml': 'application/xml',
+  '.zip': 'application/zip',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.svg': 'image/svg+xml',
+  '.mp4': 'video/mp4',
+  '.mp3': 'audio/mpeg',
+};
+
+// Maximum total size for all attachments. Gmail's 25MB limit applies to the
+// entire MIME message, and base64 encoding inflates binary data by ~33%, so
+// cap raw attachment bytes at 18MB to leave room for encoding overhead and
+// message headers/body.
+const MAX_TOTAL_ATTACHMENT_SIZE_BYTES = 18 * 1024 * 1024;
+
+function getMimeTypeFromExtension(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  return EXTENSION_MIME_MAP[ext] ?? 'application/octet-stream';
+}
+
+type AttachmentInput = {
+  filePath: string;
+  filename?: string;
+  mimeType?: string;
+};
+
 // Type definitions for email parameters
 type SendEmailParams = {
   to: string | string[];
@@ -25,11 +70,13 @@ type SendEmailParams = {
   body: string;
   cc?: string | string[];
   bcc?: string | string[];
+  replyTo?: string;
   isHtml?: boolean;
 };
 
 type CreateDraftParams = SendEmailParams & {
   threadId?: string;
+  attachments?: AttachmentInput[];
 };
 
 interface GmailAttachment {
@@ -416,6 +463,7 @@ export class GmailService {
     body,
     cc,
     bcc,
+    replyTo,
     isHtml = false,
   }: SendEmailParams) => {
     try {
@@ -424,6 +472,7 @@ export class GmailService {
         emailArraySchema.parse(to);
         if (cc) emailArraySchema.parse(cc);
         if (bcc) emailArraySchema.parse(bcc);
+        if (replyTo) emailArraySchema.parse(replyTo);
       } catch (error) {
         return {
           content: [
@@ -448,6 +497,7 @@ export class GmailService {
         body,
         cc: cc ? (Array.isArray(cc) ? cc.join(', ') : cc) : undefined,
         bcc: bcc ? (Array.isArray(bcc) ? bcc.join(', ') : bcc) : undefined,
+        replyTo,
         isHtml,
       });
 
@@ -489,10 +539,33 @@ export class GmailService {
     body,
     cc,
     bcc,
+    replyTo,
     isHtml = false,
     threadId,
+    attachments,
   }: CreateDraftParams) => {
     try {
+      // Validate email addresses
+      try {
+        emailArraySchema.parse(to);
+        if (cc) emailArraySchema.parse(cc);
+        if (bcc) emailArraySchema.parse(bcc);
+        if (replyTo) emailArraySchema.parse(replyTo);
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                error: 'Invalid email address format',
+                details:
+                  error instanceof Error ? error.message : 'Validation failed',
+              }),
+            },
+          ],
+        };
+      }
+
       logToFile(`Creating draft - to: ${to}, subject: ${subject}`);
 
       const gmail = await this.getGmailClient();
@@ -534,16 +607,79 @@ export class GmailService {
       }
 
       // Create MIME message
-      const mimeMessage = MimeHelper.createMimeMessage({
-        to: Array.isArray(to) ? to.join(', ') : to,
-        subject,
-        body,
-        cc: cc ? (Array.isArray(cc) ? cc.join(', ') : cc) : undefined,
-        bcc: bcc ? (Array.isArray(bcc) ? bcc.join(', ') : bcc) : undefined,
-        isHtml,
-        inReplyTo,
-        references,
-      });
+      let mimeMessage: string;
+
+      if (attachments && attachments.length > 0) {
+        // Validate all paths are absolute and check file sizes before reading anything
+        const attachmentSizes = await Promise.all(
+          attachments.map(async (att) => {
+            if (!path.isAbsolute(att.filePath)) {
+              throw new Error(
+                `Attachment filePath must be an absolute path: ${att.filePath}`,
+              );
+            }
+
+            try {
+              const stats = await fs.stat(att.filePath);
+              if (!stats.isFile()) {
+                throw new Error(
+                  `Attachment path is not a file: ${att.filePath}`,
+                );
+              }
+              return stats.size;
+            } catch (statError) {
+              throw new Error(
+                `Could not access attachment file ${att.filePath}: ${statError instanceof Error ? statError.message : String(statError)}`,
+              );
+            }
+          }),
+        );
+        const totalSize = attachmentSizes.reduce((sum, size) => sum + size, 0);
+
+        if (totalSize > MAX_TOTAL_ATTACHMENT_SIZE_BYTES) {
+          throw new Error(
+            `Total attachment size (${(totalSize / 1024 / 1024).toFixed(2)}MB) exceeds the maximum allowed limit of ${MAX_TOTAL_ATTACHMENT_SIZE_BYTES / 1024 / 1024}MB.`,
+          );
+        }
+
+        // Read each file from disk
+        const resolvedAttachments = await Promise.all(
+          attachments.map(async (att) => {
+            const content = await fs.readFile(att.filePath);
+            return {
+              filename: att.filename ?? path.basename(att.filePath),
+              content,
+              contentType:
+                att.mimeType ?? getMimeTypeFromExtension(att.filePath),
+            };
+          }),
+        );
+
+        mimeMessage = MimeHelper.createMimeMessageWithAttachments({
+          to: Array.isArray(to) ? to.join(', ') : to,
+          subject,
+          body,
+          cc: cc ? (Array.isArray(cc) ? cc.join(', ') : cc) : undefined,
+          bcc: bcc ? (Array.isArray(bcc) ? bcc.join(', ') : bcc) : undefined,
+          replyTo,
+          inReplyTo,
+          references,
+          isHtml,
+          attachments: resolvedAttachments,
+        });
+      } else {
+        mimeMessage = MimeHelper.createMimeMessage({
+          to: Array.isArray(to) ? to.join(', ') : to,
+          subject,
+          body,
+          cc: cc ? (Array.isArray(cc) ? cc.join(', ') : cc) : undefined,
+          bcc: bcc ? (Array.isArray(bcc) ? bcc.join(', ') : bcc) : undefined,
+          replyTo,
+          isHtml,
+          inReplyTo,
+          references,
+        });
+      }
 
       const response = await gmail.users.drafts.create({
         userId: 'me',

--- a/workspace-server/src/services/GmailService.ts
+++ b/workspace-server/src/services/GmailService.ts
@@ -665,10 +665,12 @@ export class GmailService {
           attachments.map(async (att) => {
             const content = await fs.readFile(att.filePath);
             return {
-              filename: att.filename ?? path.basename(att.filePath),
+              // `||` (not `??`) so empty strings also fall back to defaults —
+              // an empty filename or MIME type is invalid in MIME headers.
+              filename: att.filename || path.basename(att.filePath),
               content,
               contentType:
-                att.mimeType ?? getMimeTypeFromExtension(att.filePath),
+                att.mimeType || getMimeTypeFromExtension(att.filePath),
             };
           }),
         );

--- a/workspace-server/src/services/GmailService.ts
+++ b/workspace-server/src/services/GmailService.ts
@@ -16,7 +16,8 @@ import {
   GMAIL_NO_LABEL_CHANGES_MESSAGE,
 } from '../utils/constants';
 import { gaxiosOptions } from '../utils/GaxiosConfig';
-import { emailArraySchema } from '../utils/validation';
+import { emailArraySchema, gmailAttachmentSchema } from '../utils/validation';
+import { z, ZodError } from 'zod';
 
 // Extension to MIME type map for common file types
 const EXTENSION_MIME_MAP: Record<string, string> = {
@@ -45,22 +46,29 @@ const EXTENSION_MIME_MAP: Record<string, string> = {
   '.mp3': 'audio/mpeg',
 };
 
-// Maximum total size for all attachments. Gmail's 25MB limit applies to the
-// entire MIME message, and base64 encoding inflates binary data by ~33%, so
-// cap raw attachment bytes at 18MB to leave room for encoding overhead and
-// message headers/body.
+// Maximum total raw (pre-encoding) size for all attachments, checked against
+// the bytes on disk. Gmail's 25MB limit applies to the entire MIME message,
+// and base64 encoding inflates binary data by ~33%: 18MB of raw bytes becomes
+// ~24MB after encoding, leaving ~1MB of headroom under the 25MB cap for
+// message headers and body.
 const MAX_TOTAL_ATTACHMENT_SIZE_BYTES = 18 * 1024 * 1024;
+
+function assertWithinAttachmentSizeLimit(totalSize: number): void {
+  if (totalSize > MAX_TOTAL_ATTACHMENT_SIZE_BYTES) {
+    throw new Error(
+      `Total attachment size (${(totalSize / 1024 / 1024).toFixed(2)}MB) exceeds the maximum allowed limit of ${MAX_TOTAL_ATTACHMENT_SIZE_BYTES / 1024 / 1024}MB.`,
+    );
+  }
+}
 
 function getMimeTypeFromExtension(filePath: string): string {
   const ext = path.extname(filePath).toLowerCase();
   return EXTENSION_MIME_MAP[ext] ?? 'application/octet-stream';
 }
 
-type AttachmentInput = {
-  filePath: string;
-  filename?: string;
-  mimeType?: string;
-};
+// Derived from the shared zod schema (also used for the MCP tool input in
+// index.ts) so the runtime validation and this type cannot drift apart.
+type AttachmentInput = z.infer<typeof gmailAttachmentSchema>;
 
 // Type definitions for email parameters
 type SendEmailParams = {
@@ -479,14 +487,20 @@ export class GmailService {
       if (replyTo) emailArraySchema.parse(replyTo);
       return null;
     } catch (error) {
+      // Only Zod validation failures mean the addresses were malformed;
+      // anything else is an internal fault and must not be mislabeled as an
+      // invalid-email error, so rethrow it for the caller's generic handler.
+      if (!(error instanceof ZodError)) {
+        throw error;
+      }
+      logToFile(`Rejected invalid email address input: ${error.message}`);
       return {
         content: [
           {
             type: 'text' as const,
             text: JSON.stringify({
               error: 'Invalid email address format',
-              details:
-                error instanceof Error ? error.message : 'Validation failed',
+              details: error.message,
             }),
           },
         ],
@@ -653,17 +667,19 @@ export class GmailService {
           }),
         );
         const totalSize = attachmentSizes.reduce((sum, size) => sum + size, 0);
-
-        if (totalSize > MAX_TOTAL_ATTACHMENT_SIZE_BYTES) {
-          throw new Error(
-            `Total attachment size (${(totalSize / 1024 / 1024).toFixed(2)}MB) exceeds the maximum allowed limit of ${MAX_TOTAL_ATTACHMENT_SIZE_BYTES / 1024 / 1024}MB.`,
-          );
-        }
+        assertWithinAttachmentSizeLimit(totalSize);
 
         // Read each file from disk
         const resolvedAttachments = await Promise.all(
           attachments.map(async (att) => {
-            const content = await fs.readFile(att.filePath);
+            let content: Buffer;
+            try {
+              content = await fs.readFile(att.filePath);
+            } catch (readError) {
+              throw new Error(
+                `Could not read attachment file ${att.filePath}: ${readError instanceof Error ? readError.message : String(readError)}`,
+              );
+            }
             return {
               // `||` (not `??`) so empty strings also fall back to defaults —
               // an empty filename or MIME type is invalid in MIME headers.
@@ -673,6 +689,14 @@ export class GmailService {
                 att.mimeType || getMimeTypeFromExtension(att.filePath),
             };
           }),
+        );
+
+        // The stat-based check above is a pre-flight guard so oversized files
+        // are rejected before being read into memory, but a file can change
+        // between stat and read (TOCTOU). Re-check against the bytes actually
+        // read so the size cap is authoritative.
+        assertWithinAttachmentSizeLimit(
+          resolvedAttachments.reduce((sum, att) => sum + att.content.length, 0),
         );
 
         mimeMessage = MimeHelper.createMimeMessageWithAttachments({

--- a/workspace-server/src/utils/MimeHelper.ts
+++ b/workspace-server/src/utils/MimeHelper.ts
@@ -102,6 +102,9 @@ export class MimeHelper {
     from,
     cc,
     bcc,
+    replyTo,
+    inReplyTo,
+    references,
     attachments,
     isHtml = false,
   }: {
@@ -111,6 +114,9 @@ export class MimeHelper {
     from?: string;
     cc?: string;
     bcc?: string;
+    replyTo?: string;
+    inReplyTo?: string;
+    references?: string;
     attachments?: Array<{
       filename: string;
       content: Buffer | string;
@@ -134,6 +140,9 @@ export class MimeHelper {
     if (bcc) {
       messageParts.push(`Bcc: ${bcc}`);
     }
+    if (replyTo) {
+      messageParts.push(`Reply-To: ${replyTo}`);
+    }
     messageParts.push(`Subject: ${utf8Subject}`);
     messageParts.push('MIME-Version: 1.0');
 
@@ -146,11 +155,20 @@ export class MimeHelper {
         from,
         cc,
         bcc,
+        replyTo,
+        inReplyTo,
+        references,
         isHtml,
       });
     }
 
     // Multipart message with attachments
+    if (inReplyTo) {
+      messageParts.push(`In-Reply-To: ${inReplyTo}`);
+    }
+    if (references) {
+      messageParts.push(`References: ${references}`);
+    }
     messageParts.push(`Content-Type: multipart/mixed; boundary="${boundary}"`);
     messageParts.push('');
 

--- a/workspace-server/src/utils/MimeHelper.ts
+++ b/workspace-server/src/utils/MimeHelper.ts
@@ -93,6 +93,27 @@ export class MimeHelper {
   }
 
   /**
+   * Strips characters that would allow MIME header injection (CR/LF and
+   * other control characters) from a header value.
+   */
+  private static sanitizeHeaderValue(value: string): string {
+    // eslint-disable-next-line no-control-regex
+    return value.replace(/[\r\n\x00-\x1f\x7f]/g, '');
+  }
+
+  /**
+   * Sanitizes a filename for safe use inside a quoted Content-Disposition
+   * filename parameter: removes control characters (preventing header
+   * injection) and escapes backslashes and double quotes (preventing
+   * parameter injection / early quote termination).
+   */
+  private static sanitizeHeaderFilename(filename: string): string {
+    return MimeHelper.sanitizeHeaderValue(filename)
+      .replace(/\\/g, '\\\\')
+      .replace(/"/g, '\\"');
+  }
+
+  /**
    * Creates a MIME message with attachments
    */
   public static createMimeMessageWithAttachments({
@@ -184,13 +205,17 @@ export class MimeHelper {
 
     // Attachments
     for (const attachment of attachments) {
-      messageParts.push(`--${boundary}`);
-      messageParts.push(
-        `Content-Type: ${attachment.contentType || 'application/octet-stream'}`,
+      const safeContentType = MimeHelper.sanitizeHeaderValue(
+        attachment.contentType || 'application/octet-stream',
       );
+      const safeFilename = MimeHelper.sanitizeHeaderFilename(
+        attachment.filename,
+      );
+      messageParts.push(`--${boundary}`);
+      messageParts.push(`Content-Type: ${safeContentType}`);
       messageParts.push('Content-Transfer-Encoding: base64');
       messageParts.push(
-        `Content-Disposition: attachment; filename="${attachment.filename}"`,
+        `Content-Disposition: attachment; filename="${safeFilename}"`,
       );
       messageParts.push('');
 

--- a/workspace-server/src/utils/MimeHelper.ts
+++ b/workspace-server/src/utils/MimeHelper.ts
@@ -60,11 +60,15 @@ export class MimeHelper {
     }
 
     if (inReplyTo) {
-      messageParts.push(`In-Reply-To: ${inReplyTo}`);
+      messageParts.push(
+        `In-Reply-To: ${MimeHelper.sanitizeHeaderValue(inReplyTo)}`,
+      );
     }
 
     if (references) {
-      messageParts.push(`References: ${references}`);
+      messageParts.push(
+        `References: ${MimeHelper.sanitizeHeaderValue(references)}`,
+      );
     }
 
     messageParts.push(`Subject: ${utf8Subject}`);
@@ -93,11 +97,12 @@ export class MimeHelper {
   }
 
   /**
-   * Strips characters that would allow MIME header injection (CR/LF and
-   * other control characters) from a header value.
+   * Strips characters that would allow MIME header injection from a header
+   * value: CR, LF, and all other C0 control characters, plus DEL (0x7f).
+   * The explicit \r\n in the regex is redundant with \x00-\x1f but kept to
+   * make the header-injection intent obvious.
    */
   private static sanitizeHeaderValue(value: string): string {
-    // eslint-disable-next-line no-control-regex
     return value.replace(/[\r\n\x00-\x1f\x7f]/g, '');
   }
 
@@ -185,10 +190,14 @@ export class MimeHelper {
 
     // Multipart message with attachments
     if (inReplyTo) {
-      messageParts.push(`In-Reply-To: ${inReplyTo}`);
+      messageParts.push(
+        `In-Reply-To: ${MimeHelper.sanitizeHeaderValue(inReplyTo)}`,
+      );
     }
     if (references) {
-      messageParts.push(`References: ${references}`);
+      messageParts.push(
+        `References: ${MimeHelper.sanitizeHeaderValue(references)}`,
+      );
     }
     messageParts.push(`Content-Type: multipart/mixed; boundary="${boundary}"`);
     messageParts.push('');

--- a/workspace-server/src/utils/validation.ts
+++ b/workspace-server/src/utils/validation.ts
@@ -5,6 +5,7 @@
  */
 
 import { z } from 'zod';
+import * as path from 'node:path';
 
 /**
  * Email validation schema
@@ -16,6 +17,37 @@ export const emailSchema = z.string().email('Invalid email format');
  * Validates multiple email addresses (for CC/BCC fields)
  */
 export const emailArraySchema = z.union([emailSchema, z.array(emailSchema)]);
+
+/**
+ * Gmail draft attachment input. Single source of truth shared by the MCP
+ * tool schema (index.ts) and GmailService's AttachmentInput type so the two
+ * definitions cannot drift apart.
+ *
+ * Note: empty-string filename/mimeType are intentionally accepted here —
+ * GmailService falls back to path-derived defaults for them.
+ */
+export const gmailAttachmentSchema = z.object({
+  filePath: z
+    .string()
+    .refine((p) => path.isAbsolute(p), {
+      message: 'filePath must be an absolute path',
+    })
+    .describe(
+      'Absolute local filesystem path to the file to attach (e.g., "/Users/name/downloads/report.pdf"). Use gmail.downloadAttachment first to save an email attachment locally before referencing it here.',
+    ),
+  filename: z
+    .string()
+    .optional()
+    .describe(
+      'Display name for the attachment in the email. Defaults to the filename portion of filePath.',
+    ),
+  mimeType: z
+    .string()
+    .optional()
+    .describe(
+      'MIME type of the attachment (e.g., "application/pdf"). Inferred from the file extension when omitted; falls back to "application/octet-stream".',
+    ),
+});
 
 /**
  * ISO 8601 datetime validation schema


### PR DESCRIPTION
Supersedes #354 (auto-closed when the source fork was deleted). Closes #359.

Adds an optional `attachments` parameter to `gmail.createDraft`, accepting absolute local file paths with optional filename override and MIME type inference from extension.

## Changes since #354 — all gemini-code-assist review comments addressed

- **(high)** Total attachment size cap lowered 25MB → **18MB**: Gmail's 25MB limit applies to the whole MIME message and base64 inflates binary content ~33%, so raw bytes are capped with headroom for encoding overhead and headers.
- **(high)** `createDraft` now validates `to`/`cc`/`bcc`/`replyTo` via `emailArraySchema`, matching `send` (returns the same structured `Invalid email address format` error).
- **(medium)** Attachment `fs.stat` checks parallelised with `Promise.all`; sizes summed before any file content is read (fail-early preserved).
- **(medium, carried from #354's final revision)** stat-before-read validation and `replyTo` parity in `MimeHelper.createMimeMessageWithAttachments` were already incorporated.

## Tests

528/528 passing, including new coverage for createDraft email validation, attachment size enforcement, multiple attachments, MIME inference, and threaded-reply drafts with attachments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)