### PR TITLE
feat(drive): add drive.replyToComment and drive.resolveComment tools

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -49,6 +49,9 @@ The extension provides the following tools:
 - `drive.downloadFile`: Downloads a file from Google Drive to a local path.
 - `drive.trashFile`: Moves a file or folder to the trash in Google Drive.
 - `drive.renameFile`: Renames a file or folder in Google Drive.
+- `drive.replyToComment`: Posts a reply to an existing comment on a Drive file.
+- `drive.resolveComment`: Marks a comment on a Drive file as resolved,
+  optionally with a closing reply.
 
 ### Google Calendar
 

--- a/workspace-server/src/__tests__/services/DriveService.test.ts
+++ b/workspace-server/src/__tests__/services/DriveService.test.ts
@@ -76,6 +76,9 @@ describe('DriveService', () => {
       comments: {
         list: jest.fn(),
       },
+      replies: {
+        create: jest.fn(),
+      },
     };
 
     // Mock the google.drive constructor
@@ -1437,6 +1440,117 @@ describe('DriveService', () => {
           fields: expect.stringContaining('action'),
         }),
       );
+    });
+  });
+
+  describe('replyToComment', () => {
+    it('should post a reply via replies.create', async () => {
+      const mockReply = {
+        id: 'reply1',
+        content: 'Thanks, fixed!',
+        author: { displayName: 'Test User', emailAddress: 'test@example.com' },
+        createdTime: '2025-01-01T00:00:00Z',
+      };
+      mockDriveAPI.replies.create.mockResolvedValue({ data: mockReply });
+
+      const result = await driveService.replyToComment({
+        fileId: 'test-doc-id',
+        commentId: 'comment1',
+        content: 'Thanks, fixed!',
+      });
+
+      expect(mockDriveAPI.replies.create).toHaveBeenCalledWith({
+        fileId: 'test-doc-id',
+        commentId: 'comment1',
+        fields: 'id, content, author(displayName, emailAddress), createdTime',
+        requestBody: { content: 'Thanks, fixed!' },
+      });
+      const reply = JSON.parse(result.content[0].text);
+      expect(reply).toEqual(mockReply);
+    });
+
+    it('should extract the file ID from a full URL', async () => {
+      mockDriveAPI.replies.create.mockResolvedValue({ data: { id: 'r' } });
+
+      await driveService.replyToComment({
+        fileId: 'https://docs.google.com/document/d/url-doc-id/edit',
+        commentId: 'comment1',
+        content: 'reply',
+      });
+
+      expect(mockDriveAPI.replies.create).toHaveBeenCalledWith(
+        expect.objectContaining({ fileId: 'url-doc-id' }),
+      );
+    });
+
+    it('should handle errors gracefully', async () => {
+      mockDriveAPI.replies.create.mockRejectedValue(new Error('Reply Error'));
+
+      const result = await driveService.replyToComment({
+        fileId: 'test-doc-id',
+        commentId: 'comment1',
+        content: 'reply',
+      });
+
+      expect(result.content[0].text).toContain('Reply Error');
+    });
+  });
+
+  describe('resolveComment', () => {
+    it('should resolve a comment via replies.create with action resolve', async () => {
+      const mockReply = {
+        id: 'reply2',
+        action: 'resolve',
+        content: '',
+        author: { displayName: 'Test User', emailAddress: 'test@example.com' },
+        createdTime: '2025-01-01T00:00:00Z',
+      };
+      mockDriveAPI.replies.create.mockResolvedValue({ data: mockReply });
+
+      const result = await driveService.resolveComment({
+        fileId: 'test-doc-id',
+        commentId: 'comment1',
+      });
+
+      expect(mockDriveAPI.replies.create).toHaveBeenCalledWith({
+        fileId: 'test-doc-id',
+        commentId: 'comment1',
+        fields:
+          'id, action, content, author(displayName, emailAddress), createdTime',
+        requestBody: { action: 'resolve', content: '' },
+      });
+      const reply = JSON.parse(result.content[0].text);
+      expect(reply.action).toBe('resolve');
+    });
+
+    it('should include an optional closing message', async () => {
+      mockDriveAPI.replies.create.mockResolvedValue({ data: { id: 'r' } });
+
+      await driveService.resolveComment({
+        fileId: 'test-doc-id',
+        commentId: 'comment1',
+        content: 'Done in the latest revision.',
+      });
+
+      expect(mockDriveAPI.replies.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          requestBody: {
+            action: 'resolve',
+            content: 'Done in the latest revision.',
+          },
+        }),
+      );
+    });
+
+    it('should handle errors gracefully', async () => {
+      mockDriveAPI.replies.create.mockRejectedValue(new Error('Resolve Error'));
+
+      const result = await driveService.resolveComment({
+        fileId: 'test-doc-id',
+        commentId: 'comment1',
+      });
+
+      expect(result.content[0].text).toContain('Resolve Error');
     });
   });
 });

--- a/workspace-server/src/__tests__/services/DriveService.test.ts
+++ b/workspace-server/src/__tests__/services/DriveService.test.ts
@@ -1517,7 +1517,7 @@ describe('DriveService', () => {
         commentId: 'comment1',
         fields:
           'id, action, content, author(displayName, emailAddress), createdTime',
-        requestBody: { action: 'resolve', content: '' },
+        requestBody: { action: 'resolve' },
       });
       const reply = JSON.parse(result.content[0].text);
       expect(reply.action).toBe('resolve');

--- a/workspace-server/src/features/feature-config.ts
+++ b/workspace-server/src/features/feature-config.ts
@@ -99,6 +99,8 @@ export const FEATURE_GROUPS: readonly FeatureGroup[] = [
       'drive.moveFile',
       'drive.trashFile',
       'drive.renameFile',
+      'drive.replyToComment',
+      'drive.resolveComment',
     ],
     defaultEnabled: true,
   },

--- a/workspace-server/src/index.ts
+++ b/workspace-server/src/index.ts
@@ -1032,6 +1032,41 @@ async function main() {
   );
 
   registerTool(
+    'drive.replyToComment',
+    {
+      description:
+        'Posts a reply to an existing comment on a Google Drive file (Docs, Sheets, Slides, etc.). Use drive.getComments to find comment IDs.',
+      inputSchema: {
+        fileId: z
+          .string()
+          .describe('The ID or URL of the file the comment belongs to.'),
+        commentId: z.string().describe('The ID of the comment to reply to.'),
+        content: z.string().min(1).describe('The reply text.'),
+      },
+    },
+    driveService.replyToComment,
+  );
+
+  registerTool(
+    'drive.resolveComment',
+    {
+      description:
+        'Marks a comment on a Google Drive file as resolved, optionally with a closing reply. Use drive.getComments to find comment IDs.',
+      inputSchema: {
+        fileId: z
+          .string()
+          .describe('The ID or URL of the file the comment belongs to.'),
+        commentId: z.string().describe('The ID of the comment to resolve.'),
+        content: z
+          .string()
+          .optional()
+          .describe('Optional closing message posted with the resolution.'),
+      },
+    },
+    driveService.resolveComment,
+  );
+
+  registerTool(
     'drive.renameFile',
     {
       description: 'Renames a file or folder in Google Drive.',

--- a/workspace-server/src/services/DriveService.ts
+++ b/workspace-server/src/services/DriveService.ts
@@ -467,6 +467,9 @@ export class DriveService {
     try {
       const drive = await this.getDriveClient();
       const id = extractDocumentId(fileId);
+      // Note: replies.create does not take supportsAllDrives (that parameter
+      // belongs to the files/drives endpoints); comment threads on Shared
+      // Drive files work through this endpoint as-is.
       const res = await drive.replies.create({
         fileId: id,
         commentId,
@@ -508,7 +511,9 @@ export class DriveService {
         commentId,
         fields:
           'id, action, content, author(displayName, emailAddress), createdTime',
-        requestBody: { action: 'resolve', content: content ?? '' },
+        requestBody: content
+          ? { action: 'resolve', content }
+          : { action: 'resolve' },
       });
 
       logToFile(`[DriveService] Resolved comment ${commentId}`);

--- a/workspace-server/src/services/DriveService.ts
+++ b/workspace-server/src/services/DriveService.ts
@@ -452,6 +452,79 @@ export class DriveService {
     }
   };
 
+  public replyToComment = async ({
+    fileId,
+    commentId,
+    content,
+  }: {
+    fileId: string;
+    commentId: string;
+    content: string;
+  }) => {
+    logToFile(
+      `[DriveService] Replying to comment ${commentId} on file: ${fileId}`,
+    );
+    try {
+      const drive = await this.getDriveClient();
+      const id = extractDocumentId(fileId);
+      const res = await drive.replies.create({
+        fileId: id,
+        commentId,
+        fields: 'id, content, author(displayName, emailAddress), createdTime',
+        requestBody: { content },
+      });
+
+      logToFile(`[DriveService] Created reply ${res.data.id}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(res.data, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      return this.handleError('drive.replyToComment', error);
+    }
+  };
+
+  public resolveComment = async ({
+    fileId,
+    commentId,
+    content,
+  }: {
+    fileId: string;
+    commentId: string;
+    content?: string;
+  }) => {
+    logToFile(
+      `[DriveService] Resolving comment ${commentId} on file: ${fileId}`,
+    );
+    try {
+      const drive = await this.getDriveClient();
+      const id = extractDocumentId(fileId);
+      const res = await drive.replies.create({
+        fileId: id,
+        commentId,
+        fields:
+          'id, action, content, author(displayName, emailAddress), createdTime',
+        requestBody: { action: 'resolve', content: content ?? '' },
+      });
+
+      logToFile(`[DriveService] Resolved comment ${commentId}`);
+      return {
+        content: [
+          {
+            type: 'text' as const,
+            text: JSON.stringify(res.data, null, 2),
+          },
+        ],
+      };
+    } catch (error) {
+      return this.handleError('drive.resolveComment', error);
+    }
+  };
+
   public moveFile = async ({
     fileId,
     folderId,


### PR DESCRIPTION
## Summary

Fixes #343 by adding the two write-side Drive comment tools, complementing the existing read-only `drive.getComments`:

- **`drive.replyToComment(fileId, commentId, content)`** — posts a reply to an existing comment via [`replies.create`](https://developers.google.com/drive/api/reference/rest/v3/replies/create)
- **`drive.resolveComment(fileId, commentId, content?)`** — marks a comment resolved via `replies.create` with `action: "resolve"`, optionally posting a closing message

This closes the common agent loop of "read the comments on this doc, address them, reply and resolve" — today the read half exists but the write half requires leaving the extension.

## Design notes

- Both tools live in the **`drive.write` feature group** and reuse its existing `drive` OAuth scope — the consent surface is unchanged.
- File IDs accept full URLs (same `extractDocumentId` normalization as the other Drive tools).
- `fields` masks limit responses to id/content/author/createdTime (+ `action` for resolve), matching the `getComments` field style.

## What's included

- Service methods in `DriveService` following the existing logging/`handleError` conventions
- Tool registration with Zod schemas (`content` is `min(1)` on reply; optional on resolve)
- 6 Jest tests: request shapes for both tools, URL extraction, optional closing message, error paths
- `docs/index.md` entries

## Verification

```
npm run test && npm run lint && npm run format:check && npx tsc --noEmit --project workspace-server
```

All passing: 29 suites, 625 tests (619 existing + 6 new), eslint/prettier/tsc clean.

Made with [Cursor](https://cursor.com)